### PR TITLE
fix a incorrect fallthrough when use msi login

### DIFF
--- a/pkg/token/msi.go
+++ b/pkg/token/msi.go
@@ -53,19 +53,18 @@ func (p *managedIdentityToken) Token() (adal.Token, error) {
 			if err != nil {
 				return emptyToken, fmt.Errorf("failed to create service principal from managed identity for token refresh: %s", err)
 			}
-		}
-
-		// use a specified managedIdentity resource id
-		spt, err = adal.NewServicePrincipalTokenFromMSIWithIdentityResourceID(
-			msiEndpoint,
-			p.resourceID,
-			p.identityResourceID,
-			callback)
-		if err != nil {
-			return emptyToken, fmt.Errorf("failed to create service principal from managed identity %s for token refresh: %s", p.identityResourceID, err)
+		} else {
+			// use a specified managedIdentity resource id
+			spt, err = adal.NewServicePrincipalTokenFromMSIWithIdentityResourceID(
+				msiEndpoint,
+				p.resourceID,
+				p.identityResourceID,
+				callback)
+			if err != nil {
+				return emptyToken, fmt.Errorf("failed to create service principal from managed identity %s for token refresh: %s", p.identityResourceID, err)
+			}
 		}
 	} else {
-
 		// use a specified clientId
 		spt, err = adal.NewServicePrincipalTokenFromMSIWithUserAssignedID(
 			msiEndpoint,

--- a/pkg/token/msi.go
+++ b/pkg/token/msi.go
@@ -61,7 +61,7 @@ func (p *managedIdentityToken) Token() (adal.Token, error) {
 				p.identityResourceID,
 				callback)
 			if err != nil {
-				return emptyToken, fmt.Errorf("failed to create service principal from managed identity %s for token refresh: %s", p.identityResourceID, err)
+				return emptyToken, fmt.Errorf("failed to create service principal from managed identity with identityResourceID %s for token refresh: %s", p.identityResourceID, err)
 			}
 		}
 	} else {


### PR DESCRIPTION
after spt created from ```NewServicePrincipalTokenFromMSI```, it invokes ```NewServicePrincipalTokenFromMSIWithIdentityResourceID``` right after without any condition guard, which is wrong, and should be guard with else condition.