### PR TITLE
BUGFIX: Refresh token is removed from credentials when it is used

### DIFF
--- a/pkg/token/execCredentialPlugin.go
+++ b/pkg/token/execCredentialPlugin.go
@@ -85,12 +85,18 @@ func (p *execCredentialPlugin) Do() error {
 				return fmt.Errorf("failed to get refresher: %s", err)
 			}
 			klog.V(5).Info("refresh token")
+			refreshToken := token.RefreshToken
 			token, err := refresher.Token()
+
 			// if refresh fails, we will login using token provider
 			if err != nil {
 				klog.V(5).Infof("refresh failed, will continue to login: %s", err)
 			} else {
 				tokenRefreshed = true
+			}
+
+			if token.RefreshToken == "" {
+				token.RefreshToken = refreshToken
 			}
 
 			if tokenRefreshed {


### PR DESCRIPTION
The observed behavior is that when the access token expires and the refresh token is used to fetch a new access token, the refresh token is lost. The result is that when the access token expires again, there is no refresh token and the user is prompted to re-authenticate. This becomes a huge pain point when people are trying to do a days work because it means having to re-authenticate several times per day.

This change adds the refresh token back to the token object and allows the user to successively refresh their access token until the refresh token expires.