### PR TITLE
Create sha256sum of zip files, addresses  #72

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,17 @@ jobs:
       with:
         args: zip -qq -r kubelogin-linux-amd64.zip bin/linux_amd64
 
+    - name: Create sha256 Checksums
+      run: |
+        sha256sum kubelogin.zip > kubelogin.zip.sha256
+        sha256sum kubelogin-win-amd64.zip > kubelogin-win-amd64.zip.sha256
+        sha256sum kubelogin-darwin-amd64.zip > kubelogin-darwin-amd64.zip.sha256
+        sha256sum kubelogin-darwin-arm64.zip > kubelogin-darwin-arm64.zip.sha256
+        sha256sum kubelogin-linux-amd64.zip > kubelogin-linux-amd64.zip.sha256
+
     - name: Publish
       uses: skx/github-action-publish-binaries@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip
+        args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 


### PR DESCRIPTION
Minor changes to release.yml to address https://github.com/Azure/kubelogin/issues/72 

Screenshot of release with .sha256:


![Screenshot at 2021-10-14 09-05-12](https://user-images.githubusercontent.com/37632871/137355360-0dc8bca2-8074-4849-a9d0-f4f643fb85bc.png)
