### PR TITLE
Federated identity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a [client-go credential (exec) plugin](https://kubernetes.io/docs/refere
 - [non-interactive user principal login](<#user-principal-login-flow-non-interactive>) using [Resource owner login flow](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth-ropc)
 - [non-interactive managed service identity login](<#managed-service-identity-non-interactive>)
 - [non-interactive Azure CLI token login (AKS only)](<#azure-cli-token-login-non-interactive>)
+- [non-interactive workload identity login](<#azure-workload-federated-identity-non-interactive>)
 - AAD token will be cached locally for renewal in device code login and user principal login (ropc) flow. By default, it is saved in `~/.kube/cache/kubelogin/`
 - addresses <https://github.com/kubernetes/kubernetes/issues/86410> to remove `spn:` prefix in `audience` claim, if necessary. (based on kubeconfig or commandline argument `--legacy`)
 - [Setup for Kubernetes OIDC Provider using Azure AD](<#setup-for-kubernetes-oidc-provider-using-azure-ad>)
@@ -173,6 +174,17 @@ kubectl get no
 
 Uses an [access token](https://docs.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az_account_get_access_token) from [Azure CLI](https://github.com/Azure/azure-cli) to log in. The token will be issued against whatever tenant was logged in at the time `kubelogin convert-kubeconfig -l azurecli` was run. This login option only works with managed AAD in AKS.
 
+#### Azure Workload Federated Identity (non interactive)
+
+```sh
+export KUBECONFIG=/path/to/kubeconfig
+
+kubelogin convert-kubeconfig -l workloadidentity
+
+kubectl get no
+```
+
+Workload identity uses [Azure AD federated identity credentials](https://docs.microsoft.com/en-us/graph/api/resources/federatedidentitycredentials-overview?view=graph-rest-beta) to authenticate to AKS. Using Azure Workload Identity in AKS this works by reading the environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` and `AZURE_AUTHORITY_HOST`.
 
 ### Clean up
 
@@ -375,6 +387,26 @@ users:
           - <AAD server app ID>
           - --login
           - azurecli
+        command: kubelogin
+        env: null
+```
+
+### Workload Identity
+
+```yaml
+kind: Config
+preferences: {}
+users:
+  - name: demouser
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        args:
+          - get-token
+          - --server-id
+          - <AAD server app ID>
+          - --login
+          - workloadidentity
         command: kubelogin
         env: null
 ```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,11 @@ kubelogin convert-kubeconfig -l workloadidentity
 kubectl get no
 ```
 
-Workload identity uses [Azure AD federated identity credentials](https://docs.microsoft.com/en-us/graph/api/resources/federatedidentitycredentials-overview?view=graph-rest-beta) to authenticate to AKS. Using Azure Workload Identity in AKS this works by reading the environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE` and `AZURE_AUTHORITY_HOST`.
+Workload identity uses [Azure AD federated identity credentials](https://docs.microsoft.com/en-us/graph/api/resources/federatedidentitycredentials-overview?view=graph-rest-beta) to authenticate to Kubernetes clusters with AAD integration. This works by setting the environment variables:
+* `AZURE_CLIENT_ID` is Azure Active Directory application ID that is federated with workload identity
+* `AZURE_TENANT_ID` is Azure Active Directory tenant ID
+* `AZURE_FEDERATED_TOKEN_FILE` is the file containing signed assertion of workload identity. E.g. Kubernetes projected service account (jwt) token
+* `AZURE_AUTHORITY_HOST` is the base URL of an Azure Active Directory authority. E.g. https://login.microsoftonline.com
 
 ### Clean up
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.8.0
 	github.com/Azure/go-autorest/autorest v0.11.17
 	github.com/Azure/go-autorest/autorest/adal v0.9.12
+	github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0
 	github.com/golang/mock v1.4.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0 h1:WVsrXCnHlDDX8ls+tootqRE87/hL9S/g4ewig9RsD/c=
+github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -167,6 +169,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -275,6 +279,8 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -307,6 +313,7 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
@@ -323,8 +330,9 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 h1:Qj1ukM4GlMWXNdMBuXcXfz/Kw9s1qm0CLY32QxuSImI=
+github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -523,6 +531,7 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -49,7 +49,7 @@ func Convert(o Options) error {
 		return fmt.Errorf("unable to load kubeconfig: %s", err)
 	}
 
-	// MSI and AzureCLI login bypass most login fields, so we'll check for them and exclude them
+	// MSI, AzureCLI, and WorkloadIdentity login bypass most login fields, so we'll check for them and exclude them
 	isMSI := o.TokenOptions.LoginMethod == token.MSILogin
 	isAzureCLI := o.TokenOptions.LoginMethod == token.AzureCLILogin
 	isWorkloadIdentity := o.TokenOptions.LoginMethod == token.WorkloadIdentityLogin

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -52,7 +52,8 @@ func Convert(o Options) error {
 	// MSI and AzureCLI login bypass most login fields, so we'll check for them and exclude them
 	isMSI := o.TokenOptions.LoginMethod == token.MSILogin
 	isAzureCLI := o.TokenOptions.LoginMethod == token.AzureCLILogin
-	isAlternativeLogin := isMSI || isAzureCLI
+	isWorkloadIdentity := o.TokenOptions.LoginMethod == token.WorkloadIdentityLogin
+	isAlternativeLogin := isMSI || isAzureCLI || isWorkloadIdentity
 
 	for _, authInfo := range config.AuthInfos {
 		if authInfo != nil {

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -71,6 +71,24 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			name: "convert token with workload identity",
+			authProviderConfig: map[string]string{
+				cfgEnvironment: envName,
+				cfgApiserverID: serverID,
+				cfgClientID:    clientID,
+				cfgTenantID:    tenantID,
+				cfgConfigMode:  "0",
+			},
+			overrideFlags: map[string]string{
+				flagLoginMethod: token.WorkloadIdentityLogin,
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argLoginMethod, token.WorkloadIdentityLogin,
+			},
+		},
+		{
 			name: "convert token with override flags in default legacy mode",
 			overrideFlags: map[string]string{
 				flagEnvironment:  envName,

--- a/pkg/token/execCredentialPlugin.go
+++ b/pkg/token/execCredentialPlugin.go
@@ -34,7 +34,7 @@ func New(o *Options) (ExecCredentialPlugin, error) {
 		return nil, err
 	}
 	disableTokenCache := false
-	if o.LoginMethod == ServicePrincipalLogin || o.LoginMethod == MSILogin {
+	if o.LoginMethod == ServicePrincipalLogin || o.LoginMethod == MSILogin || o.LoginMethod == WorkloadIdentityLogin {
 		disableTokenCache = true
 	}
 	return &execCredentialPlugin{

--- a/pkg/token/federatedIdentity.go
+++ b/pkg/token/federatedIdentity.go
@@ -1,0 +1,94 @@
+package token
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/AzureAD/microsoft-authentication-library-for-go/apps/confidential"
+)
+
+type workloadIdentityToken struct {
+	clientID           string
+	tenantID           string
+	federatedTokenFile string
+	authorityHost      string
+	resourceID         string
+}
+
+func newWorkloadIdentityToken(clientID, federatedTokenFile, authorityHost, resourceID, tenantID string) (TokenProvider, error) {
+	if clientID == "" {
+		return nil, errors.New("clientID cannot be empty")
+	}
+	if tenantID == "" {
+		return nil, errors.New("tenantID cannot be empty")
+	}
+	if federatedTokenFile == "" {
+		return nil, errors.New("federatedTokenFile cannot be empty")
+	}
+	if authorityHost == "" {
+		return nil, errors.New("authorityHost cannot be empty")
+	}
+	if resourceID == "" {
+		return nil, errors.New("resourceID cannot be empty")
+	}
+
+	return &workloadIdentityToken{
+		clientID:           clientID,
+		tenantID:           tenantID,
+		federatedTokenFile: federatedTokenFile,
+		authorityHost:      authorityHost,
+		resourceID:         resourceID,
+	}, nil
+}
+
+func (p *workloadIdentityToken) Token() (adal.Token, error) {
+	emptyToken := adal.Token{}
+
+	signedAssertion, err := readJWTFromFS(p.federatedTokenFile)
+	if err != nil {
+		return emptyToken, fmt.Errorf("failed to read service account token: %s", err)
+	}
+	cred, err := confidential.NewCredFromAssertion(signedAssertion)
+	if err != nil {
+		return emptyToken, fmt.Errorf("failed to create confidential creds: %s", err)
+	}
+
+	// create the confidential client to request an AAD token
+	confidentialClientApp, err := confidential.New(
+		p.clientID,
+		cred,
+		confidential.WithAuthority(fmt.Sprintf("%s%s/oauth2/token", p.authorityHost, p.tenantID)))
+	if err != nil {
+		return emptyToken, fmt.Errorf("failed to create confidential client app. %s", err)
+	}
+
+	resource := strings.TrimSuffix(p.resourceID, "/")
+	// .default needs to be added to the scope
+	if !strings.HasSuffix(resource, ".default") {
+		resource += "/.default"
+	}
+
+	result, err := confidentialClientApp.AcquireTokenByCredential(context.Background(), []string{resource})
+	if err != nil {
+		return emptyToken, fmt.Errorf("failed to acquire token. %s", err)
+	}
+
+	return adal.Token{
+		AccessToken: result.AccessToken,
+		ExpiresOn:   json.Number(fmt.Sprintf("%v", result.ExpiresOn.UTC().Second())),
+	}, nil
+}
+
+// readJWTFromFS reads the jwt from file system
+func readJWTFromFS(tokenFilePath string) (string, error) {
+	token, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		return "", err
+	}
+	return string(token), nil
+}

--- a/pkg/token/federatedIdentity.go
+++ b/pkg/token/federatedIdentity.go
@@ -80,7 +80,7 @@ func (p *workloadIdentityToken) Token() (adal.Token, error) {
 
 	return adal.Token{
 		AccessToken: result.AccessToken,
-		ExpiresOn:   json.Number(fmt.Sprintf("%v", result.ExpiresOn.UTC().Second())),
+		ExpiresOn:   json.Number(fmt.Sprintf("%v", result.ExpiresOn.UTC().Unix())),
 	}, nil
 }
 

--- a/pkg/token/provider.go
+++ b/pkg/token/provider.go
@@ -30,6 +30,8 @@ func newTokenProvider(o *Options) (TokenProvider, error) {
 		return newManagedIdentityToken(o.ClientID, o.IdentityResourceId, o.ServerID)
 	case AzureCLILogin:
 		return newAzureCLIToken(*oAuthConfig, o.ServerID)
+	case WorkloadIdentityLogin:
+		return newWorkloadIdentityToken(o.ClientID, o.FederatedTokenFile, o.AuthorityHost, o.ServerID, o.TenantID)
 	}
 
 	return nil, errors.New("unsupported token provider")


### PR DESCRIPTION
Add support for using federated workload identity

```bash
kubelogin get-token --login workloadidentity --server-id 6dae42f8-4368-4678-94ff-3960e28e3643
```

Works out of the box with the new azure-workload-identity (pod-identity v2) service in AKS. Our use case is making ArgoCD authenticate to other clusters with a federated identity instead of providing it with username / password.