### PR TITLE
fix: store resource id to allow reusing cached token for azure cli

### DIFF
--- a/pkg/token/azurecli.go
+++ b/pkg/token/azurecli.go
@@ -58,5 +58,6 @@ func (p *AzureCLIToken) Token() (adal.Token, error) {
 	return adal.Token{
 		AccessToken: cliAccessToken.Token,
 		ExpiresOn:   expiresOn,
+		Resource:    p.resourceID,
 	}, nil
 }


### PR DESCRIPTION
I was investigating some odd performance issues when using this and found out that the cached token value was never used because its resource id was always an empty string and so it would never match the requested resource id.