### PR TITLE
tests should not touch config files

### DIFF
--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -1,8 +1,11 @@
 package converter
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Azure/kubelogin/pkg/token"
 	"github.com/spf13/pflag"
@@ -12,7 +15,18 @@ import (
 )
 
 func TestConvert(t *testing.T) {
-	os.Setenv("KUBECONFIG", "/tmp/foo.conf")
+	const _kc = "KUBECONFIG"
+	curEnvVal := os.Getenv(_kc)
+	tempCfg := fmt.Sprintf("%s/GoTests-%d.%s", os.TempDir(), time.Now().UnixNano(), _kc)
+	tempCfg = filepath.FromSlash(tempCfg)
+	os.Setenv(_kc, tempCfg)
+
+	defer func() {
+		// put it back the way it was and cleanup.
+		os.Setenv(_kc, curEnvVal)
+		os.Remove(tempCfg)
+	}()
+
 	const (
 		clusterName        = "aks"
 		envName            = "foo"

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -1,6 +1,7 @@
 package converter
 
 import (
+	"os"
 	"testing"
 
 	"github.com/Azure/kubelogin/pkg/token"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestConvert(t *testing.T) {
+	os.Setenv("KUBECONFIG", "/tmp/foo.conf")
 	const (
 		clusterName        = "aks"
 		envName            = "foo"
@@ -602,12 +604,12 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argClientID, clientID,
 				argTenantID, tenantID,
-          argTokenCacheDir, tokenCacheDir,
+				argTokenCacheDir, tokenCacheDir,
 				argEnvironment, envName,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
 			overrideFlags: map[string]string{
-				flagLoginMethod:   token.AzureCLILogin,
+				flagLoginMethod: token.AzureCLILogin,
 			},
 			expectedArgs: []string{
 				getTokenCommand,


### PR DESCRIPTION
These tests were seemingly changing the `$KUBECONFIG` file:

```bash
     1	kubeconfig changed by test TestConvert/non_azure_kubeconfig
     2	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_msi
     3	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_msi_with_client-id_override
     4	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_workload_identity
     5	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_workload_identity_with_overrides
     6	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_spn_without_setting_environment
     7	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_spn_with_clientSecret
     8	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_spn_with_clientCert
     9	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_ropc
    10	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_ropc_with_username_and_password
    11	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_azurecli
    12	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_azurecli_with_--token-cache-dir_override
    13	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_to_devicecode_with_redundant_arguments
    14	kubeconfig changed by test TestConvert/using_legacy_azure_auth_to_convert_without_--login_should_default_to_devicecode
    15	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_azurecli
    16	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_azurecli,_with_envName_as_overrides
    17	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_azurecli,_with_args_as_overrides
    18	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_devicecode
    19	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_devicecode,_with_args_as_overrides
    20	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_devicecode_without_override
    21	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_devicecode_with_--legacy
    22	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig_using_devicecode_and_--legacy,_convert_to_devicecode_should_still_have_--legacy
    23	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_azurecli
    24	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_azurecli_with_--token-cache-dir_override
    25	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig_already_having_--token-cache-dir,_convert_from_devicecode_to_azurecli
    26	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn
    27	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn_without_setting_environment
    28	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn_with_clientID
    29	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn_with_--legacy
    30	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_msi
    31	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_msi_with_clientID_override
    32	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_msi_with_identity-resource-id_override
    33	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_ropc
    34	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_ropc_with_--legacy
    35	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_ropc_with_username_and_password
    36	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_workload_identity
    37	kubeconfig changed by test TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_workload_identity_with_override

```

Tested with:

```bash
#!/bin/bash 

set -e 

runThese=(
TestConvert/non_azure_kubeconfig
TestConvert/using_legacy_azure_auth_to_convert_to_msi
TestConvert/using_legacy_azure_auth_to_convert_to_msi_with_client-id_override
TestConvert/using_legacy_azure_auth_to_convert_to_workload_identity
TestConvert/using_legacy_azure_auth_to_convert_to_workload_identity_with_overrides
TestConvert/using_legacy_azure_auth_to_convert_to_spn_without_setting_environment
TestConvert/using_legacy_azure_auth_to_convert_to_spn_with_clientSecret
TestConvert/using_legacy_azure_auth_to_convert_to_spn_with_clientCert
TestConvert/using_legacy_azure_auth_to_convert_to_ropc
TestConvert/using_legacy_azure_auth_to_convert_to_ropc_with_username_and_password
TestConvert/using_legacy_azure_auth_to_convert_to_azurecli
TestConvert/using_legacy_azure_auth_to_convert_to_azurecli_with_--token-cache-dir_override
TestConvert/using_legacy_azure_auth_to_convert_to_devicecode_with_redundant_arguments
TestConvert/using_legacy_azure_auth_with_configMode:_"1"_to_convert_to_devicecode_with_--legacy
TestConvert/using_legacy_azure_auth_to_convert_without_--login_should_default_to_devicecode
TestConvert/using_legacy_azure_auth_with_configMode:_"0"_to_convert_without_--login_should_default_to_devicecode
TestConvert/using_legacy_azure_auth_with_configMode:_"1"_to_convert_without_--login_should_result_in_devicecode_without_--legacy
TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_azurecli
TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_azurecli,_with_envName_as_overrides
TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_azurecli,_with_args_as_overrides
TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_devicecode
TestConvert/with_exec_format_kubeconfig,_convert_from_azurecli_to_devicecode,_with_args_as_overrides
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_devicecode_without_override
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_devicecode_with_--legacy
TestConvert/with_exec_format_kubeconfig_using_devicecode_and_--legacy,_convert_to_devicecode_should_still_have_--legacy
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_azurecli
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_azurecli_with_--token-cache-dir_override
TestConvert/with_exec_format_kubeconfig_already_having_--token-cache-dir,_convert_from_devicecode_to_azurecli
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn_without_setting_environment
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn_with_clientID
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_spn_with_--legacy
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_msi
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_msi_with_clientID_override
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_msi_with_identity-resource-id_override
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_ropc
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_ropc_with_--legacy
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_ropc_with_username_and_password
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_workload_identity
TestConvert/with_exec_format_kubeconfig,_convert_from_devicecode_to_workload_identity_with_override
)

src="/tmp/aks240.config.original"
export KUBECONFIG="/tmp/aks240.config"
report="/tmp/report.$RANDOM-$RANDOM-$RANDOM"

for i in ${runThese[@]}; do 
	cp $src $KUBECONFIG 
	echo "-- Test: $i"
	go test -v -run "$i"
	cmp -s $src $KUBECONFIG || { echo "kubeconfig changed by test $i";
		echo "kubeconfig changed by test $i" >> $report;
	}
done

if test -s "$report" ; then
	echo -e "\nConfigs were changed by tests"
	cat $report
	echo -e "\nSee $report for details"
else
	echo "✅ Clear"
fi

```