### PR TITLE
Support encrypted client certificates for service principal login

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -23,6 +23,7 @@ const (
 	argEnvironment        = "--environment"
 	argClientSecret       = "--client-secret"
 	argClientCert         = "--client-certificate"
+	argClientCertPassword = "--client-certificate-password"
 	argIsLegacy           = "--legacy"
 	argUsername           = "--username"
 	argPassword           = "--password"
@@ -38,6 +39,7 @@ const (
 	flagEnvironment        = "environment"
 	flagClientSecret       = "client-secret"
 	flagClientCert         = "client-certificate"
+	flagClientCertPassword = "client-certificate-password"
 	flagIsLegacy           = "legacy"
 	flagUsername           = "username"
 	flagPassword           = "password"
@@ -245,6 +247,11 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 			if o.isSet(flagClientCert) {
 				exec.Args = append(exec.Args, argClientCert)
 				exec.Args = append(exec.Args, o.TokenOptions.ClientCert)
+			}
+
+			if o.isSet(flagClientCertPassword) {
+				exec.Args = append(exec.Args, argClientCertPassword)
+				exec.Args = append(exec.Args, o.TokenOptions.ClientCertPassword)
 			}
 
 			if isLegacyConfigMode {

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -22,6 +22,7 @@ func TestConvert(t *testing.T) {
 		tenantID           = "tenantID"
 		clientSecret       = "foosecret"
 		clientCert         = "/tmp/clientcert"
+		clientCertPassword = "clientcertsecret"
 		username           = "foo123"
 		password           = "foobar"
 		loginMethod        = "devicecode"
@@ -192,6 +193,32 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			name: "using legacy azure auth to convert to spn with password-protected clientCert",
+			authProviderConfig: map[string]string{
+				cfgEnvironment: envName,
+				cfgApiserverID: serverID,
+				cfgClientID:    clientID,
+				cfgTenantID:    tenantID,
+				cfgConfigMode:  "1",
+			},
+			overrideFlags: map[string]string{
+				flagLoginMethod:        token.ServicePrincipalLogin,
+				flagClientID:           spClientID,
+				flagClientCert:         clientCert,
+				flagClientCertPassword: clientCertPassword,
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argClientID, spClientID,
+				argClientCert, clientCert,
+				argClientCertPassword, clientCertPassword,
+				argTenantID, tenantID,
+				argEnvironment, envName,
+				argLoginMethod, token.ServicePrincipalLogin,
+			},
+		},
+		{
 			name: "using legacy azure auth to convert to ropc",
 			authProviderConfig: map[string]string{
 				cfgEnvironment: envName,
@@ -305,15 +332,16 @@ func TestConvert(t *testing.T) {
 				cfgConfigMode:  "0",
 			},
 			overrideFlags: map[string]string{
-				flagEnvironment:  envName,
-				flagServerID:     serverID,
-				flagClientID:     clientID,
-				flagTenantID:     tenantID,
-				flagClientSecret: clientSecret,
-				flagClientCert:   clientCert,
-				flagUsername:     username,
-				flagPassword:     password,
-				flagLoginMethod:  loginMethod,
+				flagEnvironment:        envName,
+				flagServerID:           serverID,
+				flagClientID:           clientID,
+				flagTenantID:           tenantID,
+				flagClientSecret:       clientSecret,
+				flagClientCert:         clientCert,
+				flagClientCertPassword: clientCertPassword,
+				flagUsername:           username,
+				flagPassword:           password,
+				flagLoginMethod:        loginMethod,
 			},
 			expectedArgs: []string{
 				getTokenCommand,

--- a/pkg/token/options.go
+++ b/pkg/token/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	ClientID               string
 	ClientSecret           string
 	ClientCert             string
+	ClientCertPassword     string
 	Username               string
 	Password               string
 	ServerID               string
@@ -49,12 +50,13 @@ const (
 )
 
 var (
-	supportedLogin                  []string
-	DefaultTokenCacheDir            = homedir.HomeDir() + "/.kube/cache/kubelogin/"
-	envServicePrincipalClientID     = "AAD_SERVICE_PRINCIPAL_CLIENT_ID"
-	envServicePrincipalClientSecret = "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET"
-	envServicePrincipalClientCert   = "AAD_SERVICE_PRINCIPAL_CLIENT_CERTIFICATE"
-	envTenantID                     = "AZURE_TENANT_ID"
+	supportedLogin                        []string
+	DefaultTokenCacheDir                  = homedir.HomeDir() + "/.kube/cache/kubelogin/"
+	envServicePrincipalClientID           = "AAD_SERVICE_PRINCIPAL_CLIENT_ID"
+	envServicePrincipalClientSecret       = "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET"
+	envServicePrincipalClientCert         = "AAD_SERVICE_PRINCIPAL_CLIENT_CERTIFICATE"
+	envServicePrincipalClientCertPassword = "AAD_SERVICE_PRINCIPAL_CLIENT_CERTIFICATE_PASSWORD"
+	envTenantID                           = "AZURE_TENANT_ID"
 )
 
 func init() {
@@ -78,6 +80,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ClientID, "client-id", o.ClientID, fmt.Sprintf("AAD client application ID. It may be specified in %s environment variable", envServicePrincipalClientID))
 	fs.StringVar(&o.ClientSecret, "client-secret", o.ClientSecret, fmt.Sprintf("AAD client application secret. Used in spn login. It may be specified in %s environment variable", envServicePrincipalClientSecret))
 	fs.StringVar(&o.ClientCert, "client-certificate", o.ClientCert, fmt.Sprintf("AAD client cert in pfx. Used in spn login. It may be specified in %s environment variable", envServicePrincipalClientCert))
+	fs.StringVar(&o.ClientCertPassword, "client-certificate-password", o.ClientCertPassword, fmt.Sprintf("Password for AAD client cert. Used in spn login. It may be specified in %s environment variable", envServicePrincipalClientCertPassword))
 	fs.StringVar(&o.Username, "username", o.Username, fmt.Sprintf("user name for ropc login flow. It may be specified in %s environment variable", envROPCUsername))
 	fs.StringVar(&o.Password, "password", o.Password, fmt.Sprintf("password for ropc login flow. It may be specified in %s environment variable", envROPCPassword))
 	fs.StringVar(&o.IdentityResourceId, "identity-resource-id", o.IdentityResourceId, "Managed Identity resource id.")
@@ -88,7 +91,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.TenantID, "tenant-id", "t", o.TenantID, fmt.Sprintf("AAD tenant ID. It may be specified in %s environment variable", envTenantID))
 	fs.StringVarP(&o.Environment, "environment", "e", o.Environment, "Azure environment name")
 	fs.BoolVar(&o.IsLegacy, "legacy", o.IsLegacy, "set to true to get token with 'spn:' prefix in audience claim")
-	fs.BoolVar(&o.UseAzureRMTerraformEnv, "use-azurerm-env-vars", o.UseAzureRMTerraformEnv, "Use environment variable names of Terraform Azure Provider (ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_CLIENT_CERTIFICATE_PATH, ARM_TENANT_ID)")
+	fs.BoolVar(&o.UseAzureRMTerraformEnv, "use-azurerm-env-vars", o.UseAzureRMTerraformEnv, "Use environment variable names of Terraform Azure Provider (ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_CLIENT_CERTIFICATE_PATH, ARM_CLIENT_CERTIFICATE_PASSWORD, ARM_TENANT_ID)")
 }
 
 func (o *Options) Validate() error {
@@ -112,6 +115,7 @@ func (o *Options) UpdateFromEnv() {
 		envServicePrincipalClientID = "ARM_CLIENT_ID"
 		envServicePrincipalClientSecret = "ARM_CLIENT_SECRET"
 		envServicePrincipalClientCert = "ARM_CLIENT_CERTIFICATE_PATH"
+		envServicePrincipalClientCertPassword = "ARM_CLIENT_CERTIFICATE_PASSWORD"
 		envTenantID = "ARM_TENANT_ID"
 	}
 
@@ -123,6 +127,9 @@ func (o *Options) UpdateFromEnv() {
 	}
 	if v, ok := os.LookupEnv(envServicePrincipalClientCert); ok {
 		o.ClientCert = v
+	}
+	if v, ok := os.LookupEnv(envServicePrincipalClientCertPassword); ok {
+		o.ClientCertPassword = v
 	}
 	if v, ok := os.LookupEnv(envROPCUsername); ok {
 		o.Username = v

--- a/pkg/token/provider.go
+++ b/pkg/token/provider.go
@@ -23,7 +23,7 @@ func newTokenProvider(o *Options) (TokenProvider, error) {
 	case DeviceCodeLogin:
 		return newDeviceCodeTokenProvider(*oAuthConfig, o.ClientID, o.ServerID, o.TenantID)
 	case ServicePrincipalLogin:
-		return newServicePrincipalToken(*oAuthConfig, o.ClientID, o.ClientSecret, o.ClientCert, o.ServerID, o.TenantID)
+		return newServicePrincipalToken(*oAuthConfig, o.ClientID, o.ClientSecret, o.ClientCert, o.ClientCertPassword, o.ServerID, o.TenantID)
 	case ROPCLogin:
 		return newResourceOwnerToken(*oAuthConfig, o.ClientID, o.Username, o.Password, o.ServerID, o.TenantID)
 	case MSILogin:

--- a/pkg/token/serviceprincipaltoken.go
+++ b/pkg/token/serviceprincipaltoken.go
@@ -19,15 +19,16 @@ const (
 )
 
 type servicePrincipalToken struct {
-	clientID     string
-	clientSecret string
-	clientCert   string
-	resourceID   string
-	tenantID     string
-	oAuthConfig  adal.OAuthConfig
+	clientID           string
+	clientSecret       string
+	clientCert         string
+	clientCertPassword string
+	resourceID         string
+	tenantID           string
+	oAuthConfig        adal.OAuthConfig
 }
 
-func newServicePrincipalToken(oAuthConfig adal.OAuthConfig, clientID, clientSecret, clientCert, resourceID, tenantID string) (TokenProvider, error) {
+func newServicePrincipalToken(oAuthConfig adal.OAuthConfig, clientID, clientSecret, clientCert, clientCertPassword, resourceID, tenantID string) (TokenProvider, error) {
 	if clientID == "" {
 		return nil, errors.New("clientID cannot be empty")
 	}
@@ -45,12 +46,13 @@ func newServicePrincipalToken(oAuthConfig adal.OAuthConfig, clientID, clientSecr
 	}
 
 	return &servicePrincipalToken{
-		clientID:     clientID,
-		clientSecret: clientSecret,
-		clientCert:   clientCert,
-		resourceID:   resourceID,
-		tenantID:     tenantID,
-		oAuthConfig:  oAuthConfig,
+		clientID:           clientID,
+		clientSecret:       clientSecret,
+		clientCert:         clientCert,
+		clientCertPassword: clientCertPassword,
+		resourceID:         resourceID,
+		tenantID:           tenantID,
+		oAuthConfig:        oAuthConfig,
 	}, nil
 }
 
@@ -82,7 +84,7 @@ func (p *servicePrincipalToken) Token() (adal.Token, error) {
 		}
 
 		// Get the certificate and private key from pfx file
-		cert, rsaPrivateKey, err := decodePkcs12(certData, "")
+		cert, rsaPrivateKey, err := decodePkcs12(certData, p.clientCertPassword)
 		if err != nil {
 			return emptyToken, fmt.Errorf("failed to decode pkcs12 certificate while creating spt: %w", err)
 		}


### PR DESCRIPTION
The decryption password for reading the PKCS#12 file was previously hardcoded as the empty string. This made it impossible to use client certificates that have a password set, which was especially inconvenient in the context of Terraform, as the Azure Terraform providers do support this.