### PR TITLE
remove token cache for azurecli login

### DIFF
--- a/pkg/token/execCredentialPlugin.go
+++ b/pkg/token/execCredentialPlugin.go
@@ -34,7 +34,7 @@ func New(o *Options) (ExecCredentialPlugin, error) {
 		return nil, err
 	}
 	disableTokenCache := false
-	if o.LoginMethod == ServicePrincipalLogin || o.LoginMethod == MSILogin || o.LoginMethod == WorkloadIdentityLogin {
+	if o.LoginMethod == ServicePrincipalLogin || o.LoginMethod == MSILogin || o.LoginMethod == WorkloadIdentityLogin || o.LoginMethod == AzureCLILogin {
 		disableTokenCache = true
 	}
 	return &execCredentialPlugin{


### PR DESCRIPTION
remove token cache for azurecli login since az already does that. It ensures kubelogin would not leak the token after `az logout`

addresses #137 