### PR TITLE
Enable kubectl version lower than 1.22 to work though without triggering exit under devicelogin mode

### DIFF
--- a/pkg/token/execCredentialPlugin.go
+++ b/pkg/token/execCredentialPlugin.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -37,7 +38,9 @@ func New(o *Options) (ExecCredentialPlugin, error) {
 		if err := json.Unmarshal([]byte(env), &execCredential); err != nil {
 			return nil, fmt.Errorf("cannot convert to ExecCredential: %w", err)
 		}
-		if !execCredential.Spec.Interactive && o.LoginMethod == DeviceCodeLogin {
+		klog.V(10).Infof("KUBERNETES_EXEC_INFO is: %s", env)
+
+		if !strings.Contains(env, `"spec":{}`) && !execCredential.Spec.Interactive && o.LoginMethod == DeviceCodeLogin {
 			return nil, fmt.Errorf("devicelogin is not supported if interactiveMode is 'never'")
 		}
 	}

--- a/pkg/token/execCredentialPlugin_test.go
+++ b/pkg/token/execCredentialPlugin_test.go
@@ -173,7 +173,7 @@ func TestDeviceloginAndNonInteractive(t *testing.T) {
 	}
 }
 
-func TestKUBERNETES_EXEC_INFOIsEmpty(t *testing.T) {
+func TestKUBERNETES_EXEC_INFO(t *testing.T) {
 	testData := []struct {
 		name            string
 		execInfoEnvTest string
@@ -182,6 +182,26 @@ func TestKUBERNETES_EXEC_INFOIsEmpty(t *testing.T) {
 		{
 			name:            "KUBERNETES_EXEC_INFO is empty",
 			execInfoEnvTest: "",
+			options: Options{
+				LoginMethod: DeviceCodeLogin,
+				ClientID:    "clientID",
+				ServerID:    "serverID",
+				TenantID:    "tenantID",
+			},
+		},
+		{
+			name:            "KUBERNETES_EXEC_INFO.spec is empty for apiVersion of v1beta1",
+			execInfoEnvTest: `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{}}`,
+			options: Options{
+				LoginMethod: DeviceCodeLogin,
+				ClientID:    "clientID",
+				ServerID:    "serverID",
+				TenantID:    "tenantID",
+			},
+		},
+		{
+			name:            "KUBERNETES_EXEC_INFO.spec is empty for apiVersion of v1",
+			execInfoEnvTest: `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{}}`,
 			options: Options{
 				LoginMethod: DeviceCodeLogin,
 				ClientID:    "clientID",


### PR DESCRIPTION
Add checks on kubectl version for lower than 1.22 to issue warnings, provide upgrade options and then work through under devicelogin mode. Passed local unit tests and build successfully locally.