### PR TITLE
Revert following commits as the original assumption where devicelogin…

### DIFF
--- a/pkg/token/execCredentialPlugin.go
+++ b/pkg/token/execCredentialPlugin.go
@@ -3,14 +3,11 @@ package token
 //go:generate sh -c "mockgen -destination mock_$GOPACKAGE/execCredentialPlugin.go github.com/Azure/kubelogin/pkg/token ExecCredentialPlugin"
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/adal"
-	"k8s.io/client-go/pkg/apis/clientauthentication"
 	"k8s.io/klog"
 )
 
@@ -32,19 +29,6 @@ type execCredentialPlugin struct {
 }
 
 func New(o *Options) (ExecCredentialPlugin, error) {
-	env := os.Getenv(execInfoEnv)
-	if env != "" {
-		var execCredential clientauthentication.ExecCredential
-		if err := json.Unmarshal([]byte(env), &execCredential); err != nil {
-			return nil, fmt.Errorf("cannot convert to ExecCredential: %w", err)
-		}
-		klog.V(10).Infof("KUBERNETES_EXEC_INFO is: %s", env)
-
-		if !strings.Contains(env, `"spec":{}`) && !execCredential.Spec.Interactive && o.LoginMethod == DeviceCodeLogin {
-			return nil, fmt.Errorf("devicelogin is not supported if interactiveMode is 'never'")
-		}
-	}
-
 	klog.V(10).Info(o)
 	provider, err := newTokenProvider(o)
 	if err != nil {

--- a/pkg/token/execCredentialPlugin_test.go
+++ b/pkg/token/execCredentialPlugin_test.go
@@ -144,36 +144,7 @@ func setupMocks(t *testing.T) (*gomock.Controller, *mock_token.MockTokenCache, *
 	return ctrl, tokenCache, tokenProvider, pluginWriter
 }
 
-func TestDeviceloginAndNonInteractive(t *testing.T) {
-	testData := []struct {
-		name            string
-		execInfoEnvTest string
-		options         Options
-		expectedError   string
-	}{
-		{
-			name:            "KUBERNETES_EXEC_INFO.spec.interactive: false and login mode is devicelogin",
-			execInfoEnvTest: `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":false}}`,
-			options: Options{
-				LoginMethod: DeviceCodeLogin,
-			},
-			expectedError: "devicelogin is not supported if interactiveMode is 'never'",
-		},
-	}
-
-	for _, data := range testData {
-		t.Run(data.name, func(t *testing.T) {
-			os.Setenv("KUBERNETES_EXEC_INFO", data.execInfoEnvTest)
-			defer os.Unsetenv("KUBERNETES_EXEC_INFO")
-			ecp, err := New(&data.options)
-			if ecp != nil || err == nil || err.Error() != data.expectedError {
-				t.Fatalf("expected: return defined error, actual: did not return expected error")
-			}
-		})
-	}
-}
-
-func TestKUBERNETES_EXEC_INFO(t *testing.T) {
+func TestKUBERNETES_EXEC_INFOIsEmpty(t *testing.T) {
 	testData := []struct {
 		name            string
 		execInfoEnvTest string
@@ -182,26 +153,6 @@ func TestKUBERNETES_EXEC_INFO(t *testing.T) {
 		{
 			name:            "KUBERNETES_EXEC_INFO is empty",
 			execInfoEnvTest: "",
-			options: Options{
-				LoginMethod: DeviceCodeLogin,
-				ClientID:    "clientID",
-				ServerID:    "serverID",
-				TenantID:    "tenantID",
-			},
-		},
-		{
-			name:            "KUBERNETES_EXEC_INFO.spec is empty for apiVersion of v1beta1",
-			execInfoEnvTest: `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{}}`,
-			options: Options{
-				LoginMethod: DeviceCodeLogin,
-				ClientID:    "clientID",
-				ServerID:    "serverID",
-				TenantID:    "tenantID",
-			},
-		},
-		{
-			name:            "KUBERNETES_EXEC_INFO.spec is empty for apiVersion of v1",
-			execInfoEnvTest: `{"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1","spec":{}}`,
 			options: Options{
 				LoginMethod: DeviceCodeLogin,
 				ClientID:    "clientID",


### PR DESCRIPTION
Revert following commits as the original assumption where devicelogin shouldn't work in non-interactive mode is invalid

* Revert "Enable kubectl version lower than 1.22 to work though without triggering exit under devicelogin mode (#152)" This reverts commit 9cfbe19cef03b5d0ad738ee3abe3b01624cc2c4a.

* Revert "Gaojing/devicelogin exit when interactivemode never (#145)" This reverts commit 908abb353602fb2e41087cb274edde442b857a10.