### PR TITLE
Add support of env var convention used by azure sdk

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -13,7 +13,7 @@ func NewRootCmd(version string) *cobra.Command {
 		SilenceUsage: true,
 		Version:      version,
 		RunE: func(c *cobra.Command, args []string) error {
-			return nil
+			return c.Help()
 		},
 	}
 

--- a/pkg/token/options_test.go
+++ b/pkg/token/options_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -34,4 +35,123 @@ func TestOptions(t *testing.T) {
 			t.Fatalf("token cache directory is expected to be %s, got %s", o.TokenCacheDir, dir)
 		}
 	})
+
+	t.Run("invalid login method should return error", func(t *testing.T) {
+		o := NewOptions()
+		o.LoginMethod = "unsupported"
+		if err := o.Validate(); err == nil || !strings.Contains(err.Error(), "is not a supported login method") {
+			t.Fatalf("unsupported login method should return unsupported error. got: %s", err)
+		}
+	})
+}
+
+func TestOptionsWithEnvVars(t *testing.T) {
+	const (
+		clientID      = "clientID"
+		clientSecret  = "clientSecret"
+		certPath      = "certPath"
+		certPassword  = "password"
+		username      = "username"
+		password      = "password"
+		tenantID      = "tenantID"
+		tokenFile     = "tokenFile"
+		authorityHost = "authorityHost"
+	)
+	testCases := []struct {
+		name        string
+		envVarMap   map[string]string
+		isTerraform bool
+		expected    Options
+	}{
+		{
+			name: "setting env var using legacy env var format",
+			envVarMap: map[string]string{
+				kubeloginClientID:                  clientID,
+				kubeloginClientSecret:              clientSecret,
+				kubeloginClientCertificatePath:     certPath,
+				kubeloginClientCertificatePassword: certPassword,
+				kubeloginROPCUsername:              username,
+				kubeloginROPCPassword:              password,
+				azureTenantID:                      tenantID,
+				loginMethod:                        DeviceCodeLogin,
+			},
+			expected: Options{
+				ClientID:           clientID,
+				ClientSecret:       clientSecret,
+				ClientCert:         certPath,
+				ClientCertPassword: certPassword,
+				Username:           username,
+				Password:           password,
+				TenantID:           tenantID,
+				LoginMethod:        DeviceCodeLogin,
+				tokenCacheFile:     "---.json",
+			},
+		},
+		{
+			name:        "setting env var using terraform env var format",
+			isTerraform: true,
+			envVarMap: map[string]string{
+				terraformClientID:                  clientID,
+				terraformClientSecret:              clientSecret,
+				terraformClientCertificatePath:     certPath,
+				terraformClientCertificatePassword: certPassword,
+				terraformTenantID:                  tenantID,
+				loginMethod:                        DeviceCodeLogin,
+			},
+			expected: Options{
+				UseAzureRMTerraformEnv: true,
+				ClientID:               clientID,
+				ClientSecret:           clientSecret,
+				ClientCert:             certPath,
+				ClientCertPassword:     certPassword,
+				TenantID:               tenantID,
+				LoginMethod:            DeviceCodeLogin,
+				tokenCacheFile:         "---.json",
+			},
+		},
+		{
+			name: "setting env var using azure sdk env var format",
+			envVarMap: map[string]string{
+				azureClientID:                  clientID,
+				azureClientSecret:              clientSecret,
+				azureClientCertificatePath:     certPath,
+				azureClientCertificatePassword: certPassword,
+				azureUsername:                  username,
+				azurePassword:                  password,
+				azureTenantID:                  tenantID,
+				loginMethod:                    WorkloadIdentityLogin,
+				azureFederatedTokenFile:        tokenFile,
+				azureAuthorityHost:             authorityHost,
+			},
+			expected: Options{
+				ClientID:           clientID,
+				ClientSecret:       clientSecret,
+				ClientCert:         certPath,
+				ClientCertPassword: certPassword,
+				Username:           username,
+				Password:           password,
+				TenantID:           tenantID,
+				LoginMethod:        WorkloadIdentityLogin,
+				AuthorityHost:      authorityHost,
+				FederatedTokenFile: tokenFile,
+				tokenCacheFile:     "---.json",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVarMap {
+				t.Setenv(k, v)
+			}
+			o := Options{}
+			if tc.isTerraform {
+				o.UseAzureRMTerraformEnv = true
+			}
+			o.AddFlags(&pflag.FlagSet{})
+			o.UpdateFromEnv()
+			if o != tc.expected {
+				t.Fatalf("expected option: %+v, got %+v", tc.expected, o)
+			}
+		})
+	}
 }


### PR DESCRIPTION
* Add support of env var convention used by azure sdk (#89)
* Print help when subcommand is absent (#173)