### PR TITLE
update release archives to omit unnecessary file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,27 +58,27 @@ jobs:
     - name: Zip (win-amd64)
       uses: montudor/action-zip@v1
       with:
-        args: zip -qq -r kubelogin-win-amd64.zip bin/windows_amd64
+        args: zip -qq kubelogin-win-amd64.zip bin/windows_amd64/kubelogin.exe
 
     - name: Zip (darwin-amd64)
       uses: montudor/action-zip@v1
       with:
-        args: zip -qq -r kubelogin-darwin-amd64.zip bin/darwin_amd64
+        args: zip -qq kubelogin-darwin-amd64.zip bin/darwin_amd64/kubelogin
 
     - name: Zip (darwin-arm64)
       uses: montudor/action-zip@v1
       with:
-        args: zip -qq -r kubelogin-darwin-arm64.zip bin/darwin_arm64
+        args: zip -qq kubelogin-darwin-arm64.zip bin/darwin_arm64/kubelogin
 
     - name: Zip (linux-amd64)
       uses: montudor/action-zip@v1
       with:
-        args: zip -qq -r kubelogin-linux-amd64.zip bin/linux_amd64
+        args: zip -qq kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin
 
     - name: Zip (linux-arm64)
       uses: montudor/action-zip@v1
       with:
-        args: zip -qq -r kubelogin-linux-arm64.zip bin/linux_arm64
+        args: zip -qq kubelogin-linux-arm64.zip bin/linux_arm64/kubelogin
 
     - name: Create sha256 Checksums
       run: |


### PR DESCRIPTION
Addresses #38 

## Before
```sh
unzip -l kubelogin-darwin-amd64.zip
Archive:  kubelogin-darwin-amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  12-20-2022 21:41   bin/darwin_amd64/
 46380400  12-20-2022 21:41   bin/darwin_amd64/kubelogin
---------                     -------
 46380400                     2 files
```

## After (https://github.com/weinong/kubelogin/releases/tag/v0.0.3)
```sh
unzip -l kubelogin-darwin-amd64.zip
Archive:  kubelogin-darwin-amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 46380000  12-29-2022 09:22   bin/darwin_amd64/kubelogin
---------                     -------
 46380000                     1 file
```

## Tested
### az cli
```sh
sudo az aks install-cli --kubelogin-base-src-url https://github.com/weinong/kubelogin/releases/download --kubelogin-version v0.0.3
```
### homebrew
```sh
$ brew install -s -v ./kubelogin.rb
Error: Failed to load cask: ./kubelogin.rb
Cask 'kubelogin' is unreadable: wrong constant name #<Class:0x00007fec8d9587c0>
Warning: Treating ./kubelogin.rb as a formula.
==> Fetching kubelogin
==> Downloading https://github.com/weinong/kubelogin/releases/download/v0.0.3/kubelogin-darwin-amd64.zip
Already downloaded: /Users/weinongw/Library/Caches/Homebrew/downloads/5666d71f67bd9e03027090da21f44c7a722ae06d5bb1dbfcca8b5aac20e62881--kubelogin-darwin-amd64.zip
==> Verifying checksum for '5666d71f67bd9e03027090da21f44c7a722ae06d5bb1dbfcca8b5aac20e62881--kubelogin-darwin-amd64.zip'
Warning: kubelogin 0.0.5 is available and more recent than version 0.0.3.
/usr/bin/env PATH=/usr/local/opt/unzip/bin:/usr/local/Homebrew/Library/Homebrew/shims/mac/super:/usr/bin:/bin:/usr/sbin:/sbin unzip -o /Users/weinongw/Library/Caches/Homebrew/downloads/5666d71f67bd9e03027090da21f44c7a722ae06d5bb1dbfcca8b5aac20e62881--kubelogin-darwin-amd64.zip -d /private/tmp/d20221229-57628-1rd72kh
cp -pR /private/tmp/d20221229-57628-1rd72kh/bin/. /private/tmp/kubelogin-20221229-57628-4pgmdf/bin
chmod -Rf +w /private/tmp/d20221229-57628-1rd72kh
==> Cleaning
==> Finishing up
ln -s ../Cellar/kubelogin/0.0.3/bin/kubelogin kubelogin
==> Summary
🍺  /usr/local/Cellar/kubelogin/0.0.3: 3 files, 44.2MB, built in 3 seconds
==> Running `brew cleanup kubelogin`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/weinongw/Library/Caches/Homebrew/kubelogin--0.0.3.zip... (20MB)
$  kubelogin --version                                     took 7s at 11:26:55 AM
kubelogin version
git hash: v0.0.3/23f6fecc78189a9c24a2a33283289b8f84c70aa4
Go version: go1.19.4
Build time: 2022-12-29T17:21:48Z
Platform: darwin/amd64
```