### PR TITLE
Fix/release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,33 @@ jobs:
         go-version: 1.19
       id: go
 
+    # Read changelog and read versions etc.
+    - name: Check version is mentioned in Changelog.md
+      id: changelog_reader
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_depth: 10
+        path: 'CHANGELOG.md'
+    # Check if the newest tag already exists
+    - name: Check if tag exist
+      uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0
+      id: check-tag-exists
+      with:
+        tag:  "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Create Release with artifacts
+    - name: Create Kubelogin Release
+      id: create_release
+      if: ${{ steps.check-tag-exists.outputs.exists == 'false'}}
+      uses: softprops/action-gh-release@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name : "v${{ steps.changelog_reader.outputs.version }}"
+        name: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
+        body: ${{ steps.changelog_reader.outputs.changes }}
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
@@ -90,33 +117,6 @@ jobs:
         sha256sum kubelogin-darwin-arm64.zip > kubelogin-darwin-arm64.zip.sha256
         sha256sum kubelogin-linux-amd64.zip > kubelogin-linux-amd64.zip.sha256
         sha256sum kubelogin-linux-arm64.zip > kubelogin-linux-arm64.zip.sha256
-
-    # Read changelog and read versions etc.
-    - name: Check version is mentioned in Changelog.md
-      id: changelog_reader
-      uses: mindsers/changelog-reader-action@v2
-      with:
-        validation_depth: 10
-        path: 'CHANGELOG.md'
-    # Check if the newest tag already exists
-    - name: Check if tag exist
-      uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0
-      id: check-tag-exists
-      with:
-        tag:  "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # Create Release with artifacts
-    - name: Create Kubelogin Release
-      id: create_release
-      if: ${{ steps.check-tag-exists.outputs.exists == 'false'}}
-      uses: softprops/action-gh-release@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name : "v${{ steps.changelog_reader.outputs.version }}"
-        name: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
-        body: ${{ steps.changelog_reader.outputs.changes }}
 
     - name: Publish
       uses: skx/github-action-publish-binaries@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
         go-version: 1.19
       id: go
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     # Read changelog and read versions etc.
     - name: Check version is mentioned in Changelog.md
       id: changelog_reader
@@ -42,8 +45,9 @@ jobs:
         name: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
         body: ${{ steps.changelog_reader.outputs.changes }}
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+    # We need the latest tag in the git local workspace before it start building. 
+    - name: Get tags
+      run: git fetch --tags
 
     - name: Build (linux)
       env:


### PR DESCRIPTION
This PR fixes : #188 , thank you so much for reporting this.

### TLDR:

The issue was the missing automation for `pull tags` to provide all latest tags before build for the `version information` to follow.

### Little extra:

Previously we were creating the tags after `build` and also since we are now automating everything, I completely missed out this part of the code which was handling the version and not we are making sure all tags are there so the hash with the latest tag matches.

<img width="707" alt="Screenshot 2023-02-09 at 1 06 49 PM" src="https://user-images.githubusercontent.com/6233295/217680267-7af58d46-c6b4-41e4-9acd-180330fdccc1.png">


As a result here is what I get Before and After:

### Before fix

<img width="638" alt="Screenshot 2023-02-09 at 11 51 03 AM" src="https://user-images.githubusercontent.com/6233295/217680804-597b6218-0887-42de-8e01-d29b1d4273ea.png">


### After Fix


<img width="993" alt="Screenshot 2023-02-09 at 1 10 47 PM" src="https://user-images.githubusercontent.com/6233295/217680863-fe84f86d-a415-4cfb-abb0-8a56eb36ee70.png">


Thank you so much for this, really appreciate it. ❤️☕️🙏 





