### PR TITLE
ci: remove snapstore publish step from push action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,7 @@ jobs:
         GOOS: windows
         GOARCH: arm64
       run: make
+
+    - name: Snap Build
+      uses: snapcore/action-build@v1
+      id: snapbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      GO111MODULE: on 
+      GO111MODULE: on
     steps:
     - name: Set up Go 1.19
       uses: actions/setup-go@v3
@@ -57,18 +57,3 @@ jobs:
         GOOS: windows
         GOARCH: arm64
       run: make
-
-    - name: Snap Build
-      uses: snapcore/action-build@v1
-      id: snapbuild
-
-    - name: Publish to Snap Store
-      uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_LOGIN }}
-      with:
-        snap: ${{ steps.snapbuild.outputs.snap }}
-        release: edge
-      if: |
-        github.repository == 'Azure/kubelogin' &&
-        github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0
       id: check-tag-exists
       with:
-        tag:  "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
+        tag: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # Create Release with artifacts
@@ -39,9 +39,9 @@ jobs:
       if: ${{ steps.check-tag-exists.outputs.exists == 'false'}}
       uses: softprops/action-gh-release@v1
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name : "v${{ steps.changelog_reader.outputs.version }}"
+        tag_name: "v${{ steps.changelog_reader.outputs.version }}"
         name: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
         body: ${{ steps.changelog_reader.outputs.changes }}
 
@@ -135,17 +135,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-<<<<<<< HEAD
         args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-win-arm64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin-linux-arm64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-win-arm64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 kubelogin-linux-arm64.zip.sha256
-        releaseId: ${{ steps.create_release.outputs.id }}
-
-    - name: Publish to Snap Store
-      uses: snapcore/action-publish@v1
-      env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_LOGIN }}
-      with:
-        snap: ${{ steps.snapbuild.outputs.snap }}
-        release: stable
-=======
-        args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin-linux-arm64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 kubelogin-linux-arm64.zip.sha256
->>>>>>> parent of 1099683 (update workflow to build and publish snap package (#183))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,3 +136,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-win-arm64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin-linux-arm64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-win-arm64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 kubelogin-linux-arm64.zip.sha256
+        releaseId: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,6 @@ jobs:
         GOARCH: arm64
       run: make
 
-    - name: Snap Build
-      uses: snapcore/action-build@v1
-      id: snapbuild
-
     - name: Zip
       uses: montudor/action-zip@v1
       with:
@@ -139,6 +135,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
+<<<<<<< HEAD
         args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-win-arm64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin-linux-arm64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-win-arm64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 kubelogin-linux-arm64.zip.sha256
         releaseId: ${{ steps.create_release.outputs.id }}
 
@@ -149,3 +146,6 @@ jobs:
       with:
         snap: ${{ steps.snapbuild.outputs.snap }}
         release: stable
+=======
+        args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin-linux-arm64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 kubelogin-linux-arm64.zip.sha256
+>>>>>>> parent of 1099683 (update workflow to build and publish snap package (#183))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0
       id: check-tag-exists
       with:
-        tag: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
+        tag:  "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # Create Release with artifacts
@@ -39,9 +39,9 @@ jobs:
       if: ${{ steps.check-tag-exists.outputs.exists == 'false'}}
       uses: softprops/action-gh-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: "v${{ steps.changelog_reader.outputs.version }}"
+        tag_name : "v${{ steps.changelog_reader.outputs.version }}"
         name: "v${{ steps.changelog_reader.outputs.version }} release" # following the pattern of vx.x.xx release used in this repo
         body: ${{ steps.changelog_reader.outputs.changes }}
 
@@ -84,6 +84,10 @@ jobs:
         GOOS: windows
         GOARCH: arm64
       run: make
+
+    - name: Snap Build
+      uses: snapcore/action-build@v1
+      id: snapbuild
 
     - name: Zip
       uses: montudor/action-zip@v1
@@ -137,3 +141,11 @@ jobs:
       with:
         args: kubelogin.zip kubelogin-win-amd64.zip kubelogin-win-arm64.zip kubelogin-darwin-amd64.zip kubelogin-darwin-arm64.zip kubelogin-linux-amd64.zip kubelogin-linux-arm64.zip kubelogin.zip.sha256 kubelogin-win-amd64.zip.sha256 kubelogin-win-arm64.zip.sha256 kubelogin-darwin-amd64.zip.sha256 kubelogin-darwin-arm64.zip.sha256 kubelogin-linux-amd64.zip.sha256 kubelogin-linux-arm64.zip.sha256
         releaseId: ${{ steps.create_release.outputs.id }}
+
+    - name: Publish to Snap Store
+      uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPSTORE_LOGIN }}
+      with:
+        snap: ${{ steps.snapbuild.outputs.snap }}
+        release: stable


### PR DESCRIPTION
The snap build seems broken and preventing depedantbot's PR builds.