### PR TITLE
Document scoop installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ winget install --id=Kubernetes.kubectl  -e
 winget install --id=Microsoft.Azure.Kubelogin  -e
 ```
 
+#### Using scoop
+
+From Powershell:
+``` powershell
+scoop install kubectl azure-kubelogin
+```
+
 #### Using azure cli
 
 From Powershell:


### PR DESCRIPTION
It's possible to install `kubelogin` using [scoop](https://github.com/ScoopInstaller/Scoop#scoop) installer. The [manifest file](https://github.com/ScoopInstaller/Main/blob/master/bucket/azure-kubelogin.json) is automatically updated when a [new release](https://github.com/Azure/kubelogin/releases) comes out.