### PR TITLE
add --context support in convert subcommand

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -149,7 +149,17 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 		return fmt.Errorf("unable to load kubeconfig: %s", err)
 	}
 
-	for _, authInfo := range config.AuthInfos {
+	targetAuthInfo := ""
+
+	if o.context != "" && config.Contexts[o.context] != nil {
+		targetAuthInfo = config.Contexts[o.context].AuthInfo
+	}
+
+	for name, authInfo := range config.AuthInfos {
+
+		if targetAuthInfo != "" && name != targetAuthInfo {
+			continue
+		}
 
 		//  is it legacy aad auth or is it exec using kubelogin?
 		if !isExecUsingkubelogin(authInfo) && !isLegacyAzureAuth(authInfo) {

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestConvert(t *testing.T) {
 	const (
-		clusterName        = "aks"
+		clusterName1       = "aks1"
+		clusterName2       = "aks2"
 		envName            = "foo"
 		serverID           = "serverID"
 		clientID           = "clientID"
@@ -38,6 +39,7 @@ func TestConvert(t *testing.T) {
 		expectedArgs       []string
 		execArgItems       []string
 		command            string
+		contextName        string
 	}{
 		{
 			name: "non azure kubeconfig",
@@ -1042,6 +1044,26 @@ func TestConvert(t *testing.T) {
 			},
 			command: execName,
 		},
+		{
+			name:        "convert with context specified, auth info not specified by the context should not be changed",
+			contextName: clusterName1,
+			authProviderConfig: map[string]string{
+				cfgEnvironment: envName,
+				cfgApiserverID: serverID,
+				cfgClientID:    clientID,
+				cfgTenantID:    tenantID,
+				cfgConfigMode:  "0",
+			},
+			overrideFlags: map[string]string{
+				flagLoginMethod: token.MSILogin,
+				"context":       clusterName1,
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argLoginMethod, token.MSILogin,
+			},
+		},
 	}
 	rootTmpDir, err := os.MkdirTemp("", "kubelogin-test")
 	if err != nil {
@@ -1060,8 +1082,9 @@ func TestConvert(t *testing.T) {
 			}
 			kubeconfigFile := filepath.Join(tmpDir, "config")
 
-			config := createValidTestConfig(
-				clusterName,
+			config := createValidTestConfigs(
+				clusterName1,
+				clusterName2,
 				data.command,
 				authProviderName,
 				data.authProviderConfig,
@@ -1071,7 +1094,7 @@ func TestConvert(t *testing.T) {
 			o := Options{
 				Flags: fs,
 				configFlags: genericclioptions.NewTestConfigFlags().
-					WithClientConfig(clientcmd.NewNonInteractiveClientConfig(*config, clusterName, &clientcmd.ConfigOverrides{}, nil)),
+					WithClientConfig(clientcmd.NewNonInteractiveClientConfig(*config, clusterName1, &clientcmd.ConfigOverrides{}, nil)),
 			}
 			o.AddFlags(fs)
 
@@ -1092,92 +1115,126 @@ func TestConvert(t *testing.T) {
 				t.Fatalf("Unexpected error from Convert: %v", err)
 			}
 
-			validate(t, config.AuthInfos[clusterName], data.authProviderConfig, data.expectedArgs)
+			if o.context != "" {
+				// when --context is specified, convert-kubeconfig will convert only the targeted context
+				// hence, we expect the second auth info not to change
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs)
+				validateAuthInfoThatShouldNotChange(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig)
+			} else {
+				// when --context is not specified, convert-kubeconfig will convert every auth info in the kubeconfig
+				// hence, we expect the second auth info to be converted in the same way as the first one
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs)
+				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs)
+			}
 		})
 	}
 }
 
-func createValidTestConfig(
-	name, commandName, authProviderName string,
+func createValidTestConfigs(
+	name1, name2, commandName, authProviderName string,
 	authProviderConfig map[string]string,
 	execArgItems []string,
 ) *clientcmdapi.Config {
 	const server = "https://anything.com:8080"
 
 	config := clientcmdapi.NewConfig()
-	config.Clusters[name] = &clientcmdapi.Cluster{
-		Server: server,
-	}
-
-	if authProviderConfig == nil && execArgItems != nil {
-		config.AuthInfos[name] = &clientcmdapi.AuthInfo{
-			Exec: &clientcmdapi.ExecConfig{
-				Args:    execArgItems,
-				Command: commandName,
-			},
+	for _, name := range []string{name1, name2} {
+		config.Clusters[name] = &clientcmdapi.Cluster{
+			Server: server,
 		}
-	} else {
-		config.AuthInfos[name] = &clientcmdapi.AuthInfo{
-			AuthProvider: &clientcmdapi.AuthProviderConfig{
-				Name:   authProviderName,
-				Config: authProviderConfig,
-			},
+
+		if authProviderConfig == nil && execArgItems != nil {
+			config.AuthInfos[name] = &clientcmdapi.AuthInfo{
+				Exec: &clientcmdapi.ExecConfig{
+					Args:    execArgItems,
+					Command: commandName,
+				},
+			}
+		} else {
+			config.AuthInfos[name] = &clientcmdapi.AuthInfo{
+				AuthProvider: &clientcmdapi.AuthProviderConfig{
+					Name:   authProviderName,
+					Config: authProviderConfig,
+				},
+			}
+		}
+
+		config.Contexts[name] = &clientcmdapi.Context{
+			Cluster:  name,
+			AuthInfo: name,
 		}
 	}
-
-	config.Contexts[name] = &clientcmdapi.Context{
-		Cluster:  name,
-		AuthInfo: name,
-	}
-	config.CurrentContext = name
+	config.CurrentContext = name1
 
 	return config
 }
 
 func validate(
 	t *testing.T,
+	clusterName string,
 	authInfo *clientcmdapi.AuthInfo,
 	authProviderConfig map[string]string,
 	expectedArgs []string,
 ) {
 	if expectedArgs == nil {
 		if authInfo.AuthProvider == nil {
-			t.Fatal("original auth provider should not be reset")
+			t.Fatalf("[context:%s]: %s", clusterName, "auth provider should not be reset")
 		}
 		if authInfo.Exec != nil {
-			t.Fatal("exec plugin should not be set")
+			t.Fatalf("[context:%s]: %s", clusterName, "plugin should not be set")
 		}
 		return
 	}
 
 	if authInfo.AuthProvider != nil {
-		t.Fatal("original auth provider should be reset")
+		t.Fatalf("[context:%s]: %s", clusterName, "auth provider should be reset")
 	}
 	exec := authInfo.Exec
 	if exec == nil {
-		t.Fatal("unable to find exec plugin")
+		t.Fatalf("[context:%s]: %s", clusterName, "unable to find exec plugin")
 	}
 
 	if exec.Command != execName {
-		t.Fatalf("expected exec command: %s, actual: %s", execName, exec.Command)
+		t.Fatalf("[context:%s]: expected exec command: %s, actual: %s", clusterName, execName, exec.Command)
 	}
 
 	if exec.APIVersion != execAPIVersion {
-		t.Fatalf("expected exec command: %s, actual: %s", execAPIVersion, exec.APIVersion)
+		t.Fatalf("[context:%s]: expected exec command: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
 	}
 
 	if len(exec.Env) > 0 {
-		t.Fatalf("expected 0 environment variable. actual: %d", len(exec.Env))
+		t.Fatalf("[context:%s]: expected 0 environment variable. actual: %d", clusterName, len(exec.Env))
 	}
 	if exec.Args[0] != getTokenCommand {
-		t.Fatalf("expected %s as first argument. actual: %s", getTokenCommand, exec.Args[0])
+		t.Fatalf("[context:%s]: expected %s as first argument. actual: %s", clusterName, getTokenCommand, exec.Args[0])
 	}
 	if len(exec.Args) != len(expectedArgs) {
-		t.Fatalf("expected exec args: %v, actual: %v", expectedArgs, exec.Args)
+		t.Fatalf("[context:%s]: expected exec args: %v, actual: %v", clusterName, expectedArgs, exec.Args)
 	}
 	for _, v := range expectedArgs {
 		if !contains(exec.Args, v) {
-			t.Fatalf("expected exec arg: %s not found in %v", v, exec.Args)
+			t.Fatalf("[context:%s]: expected exec arg: %s not found in %v", clusterName, v, exec.Args)
+		}
+	}
+}
+
+func validateAuthInfoThatShouldNotChange(
+	t *testing.T,
+	clusterName string,
+	authInfo *clientcmdapi.AuthInfo,
+	authProviderConfig map[string]string,
+) {
+	if authInfo.AuthProvider == nil {
+		t.Fatalf("[context:%s]: %s", clusterName, "auth provider should not be reset")
+	}
+	for k, v := range authInfo.AuthProvider.Config {
+		if authProviderConfig[k] != v {
+			t.Fatalf("[context:%s]: %s=%s does not match with input %s=%s", clusterName, k, v, k, authProviderConfig[k])
+		}
+	}
+	for k, v := range authProviderConfig {
+		if authInfo.AuthProvider.Config[k] != v {
+			t.Fatalf("[context:%s]: %s=%s does not match with output %s=%s", clusterName, k, v, k, authInfo.AuthProvider.Config[k])
 		}
 	}
 }

--- a/pkg/converter/options.go
+++ b/pkg/converter/options.go
@@ -10,6 +10,8 @@ type Options struct {
 	Flags        *pflag.FlagSet
 	configFlags  genericclioptions.RESTClientGetter
 	TokenOptions token.Options
+	// context is the kubeconfig context name
+	context string
 }
 
 func stringptr(str string) *string { return &str }
@@ -26,6 +28,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	if cf, ok := o.configFlags.(*genericclioptions.ConfigFlags); ok {
 		cf.AddFlags(fs)
 	}
+	fs.StringVar(&o.context, "context", "", "The name of the kubeconfig context to use")
 	o.TokenOptions.AddFlags(fs)
 }
 


### PR DESCRIPTION
it allows to convert only the selected context rather than the whole kubeconfig

fixes #87 