### PR TITLE
Adding installHint field to kubeconfigs that have been converted to the exec format

### DIFF
--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -200,8 +200,8 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 			Args: []string{
 				getTokenCommand,
 			},
-			APIVersion: execAPIVersion,
-			InstallHint: execInstallHint
+			APIVersion:  execAPIVersion,
+			InstallHint: execInstallHint,
 		}
 
 		exec.Args = append(exec.Args, argLoginMethod, o.TokenOptions.LoginMethod)

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -51,7 +51,6 @@ const (
 	flagAuthorityHost      = "authority-host"
 	flagFederatedTokenFile = "federated-token-file"
 	flagTokenCacheDir      = "token-cache-dir"
-	flagExecInstallHint    = "install-hint"
 
 	execName        = "kubelogin"
 	getTokenCommand = "get-token"
@@ -203,10 +202,6 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 			},
 			APIVersion:  execAPIVersion,
 			InstallHint: execInstallHint,
-		}
-
-		if o.execInstallHint != "" {
-			exec.InstallHint = o.execInstallHint
 		}
 
 		exec.Args = append(exec.Args, argLoginMethod, o.TokenOptions.LoginMethod)

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -208,6 +208,11 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 			InstallHint: execInstallHint,
 		}
 
+		// Preserve any existing install hint
+		if authInfo.Exec != nil && authInfo.Exec.InstallHint != "" {
+			exec.InstallHint = authInfo.Exec.InstallHint
+		}
+
 		exec.Args = append(exec.Args, argLoginMethod, o.TokenOptions.LoginMethod)
 
 		// all login methods require --server-id specified

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -58,7 +58,7 @@ const (
 	execInstallHint = `
 kubelogin is not installed which is required to connect to AAD enabled cluster.
 
-To learn more, please go to https://aka.ms/aks/kubelogin
+To learn more, please go to https://azure.github.io/kubelogin/
 `
 
 	azureConfigDir = "AZURE_CONFIG_DIR"

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -55,7 +55,11 @@ const (
 	execName        = "kubelogin"
 	getTokenCommand = "get-token"
 	execAPIVersion  = "client.authentication.k8s.io/v1beta1"
-	execInstallHint = "Install kubelogin for use with kubectl by running az aks install-cli"
+	execInstallHint = `
+kubelogin is not installed which is required to connect to AAD enabled cluster.
+
+To learn more, please go to https://aka.ms/aks/kubelogin
+`
 
 	azureConfigDir = "AZURE_CONFIG_DIR"
 )

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -51,6 +51,7 @@ const (
 	flagAuthorityHost      = "authority-host"
 	flagFederatedTokenFile = "federated-token-file"
 	flagTokenCacheDir      = "token-cache-dir"
+	flagExecInstallHint    = "install-hint"
 
 	execName        = "kubelogin"
 	getTokenCommand = "get-token"
@@ -202,6 +203,10 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 			},
 			APIVersion:  execAPIVersion,
 			InstallHint: execInstallHint,
+		}
+
+		if o.execInstallHint != "" {
+			exec.InstallHint = o.execInstallHint
 		}
 
 		exec.Args = append(exec.Args, argLoginMethod, o.TokenOptions.LoginMethod)

--- a/pkg/converter/convert.go
+++ b/pkg/converter/convert.go
@@ -55,6 +55,7 @@ const (
 	execName        = "kubelogin"
 	getTokenCommand = "get-token"
 	execAPIVersion  = "client.authentication.k8s.io/v1beta1"
+	execInstallHint = "Install kubelogin for use with kubectl by running az aks install-cli"
 
 	azureConfigDir = "AZURE_CONFIG_DIR"
 )
@@ -200,6 +201,7 @@ func Convert(o Options, pathOptions *clientcmd.PathOptions) error {
 				getTokenCommand,
 			},
 			APIVersion: execAPIVersion,
+			InstallHint: execInstallHint
 		}
 
 		exec.Args = append(exec.Args, argLoginMethod, o.TokenOptions.LoginMethod)

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -34,17 +34,19 @@ func TestConvert(t *testing.T) {
 		azureCLIDir        = "/tmp/foo"
 	)
 	testData := []struct {
-		name               string
-		authProviderConfig map[string]string
-		overrideFlags      map[string]string
-		expectedArgs       []string
-		execArgItems       []string
-		command            string
-		expectedError      string
-		expectedEnv        []clientcmdapi.ExecEnvVar
+		name                string
+		authProviderConfig  map[string]string
+		overrideFlags       map[string]string
+		expectedArgs        []string
+		execArgItems        []string
+		command             string
+		expectedError       string
+		expectedEnv         []clientcmdapi.ExecEnvVar
+		expectedInstallHint string
 	}{
 		{
-			name: "non azure kubeconfig",
+			name:                "non azure kubeconfig",
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to msi",
@@ -63,6 +65,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to msi with client-id override",
@@ -83,6 +86,7 @@ func TestConvert(t *testing.T) {
 				argClientID, "msi-client-id",
 				argLoginMethod, token.MSILogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to workload identity",
@@ -101,6 +105,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to workload identity with overrides",
@@ -127,6 +132,7 @@ func TestConvert(t *testing.T) {
 				argFederatedTokenFile, federatedTokenFile,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn without setting environment",
@@ -147,6 +153,7 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn with clientSecret",
@@ -171,6 +178,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn with clientCert",
@@ -195,6 +203,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn with password-protected clientCert",
@@ -221,6 +230,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to ropc",
@@ -242,6 +252,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to ropc with username and password",
@@ -267,6 +278,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to azurecli",
@@ -285,6 +297,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to azurecli with --tenant-id override",
@@ -305,6 +318,7 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTenantID, tenantID,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to azurecli with --token-cache-dir override",
@@ -325,6 +339,27 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTokenCacheDir, tokenCacheDir,
 			},
+			expectedInstallHint: execInstallHint,
+		},
+		{
+			name: "using legacy azure auth to convert to azurecli with --install-hint override",
+			authProviderConfig: map[string]string{
+				cfgEnvironment: envName,
+				cfgApiserverID: serverID,
+				cfgClientID:    clientID,
+				cfgTenantID:    tenantID,
+				cfgConfigMode:  "1",
+			},
+			overrideFlags: map[string]string{
+				flagLoginMethod:     token.AzureCLILogin,
+				flagExecInstallHint: "Custom Install Hint",
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argLoginMethod, token.AzureCLILogin,
+			},
+			expectedInstallHint: "Custom Install Hint",
 		},
 		{
 			name: "using legacy azure auth to convert to devicecode with redundant arguments",
@@ -356,6 +391,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, loginMethod,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth with configMode: \"1\" to convert to devicecode with --legacy",
@@ -379,6 +415,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, loginMethod,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert without --login should default to devicecode",
@@ -397,6 +434,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth with configMode: \"0\" to convert without --login should default to devicecode",
@@ -416,6 +454,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth with configMode: \"1\" to convert without --login should result in devicecode without --legacy",
@@ -434,6 +473,7 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli",
@@ -453,7 +493,8 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli with --tenant-id",
@@ -475,7 +516,8 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTenantID, tenantID,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli, with envName as overrides",
@@ -495,7 +537,8 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli, with args as overrides",
@@ -515,7 +558,8 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTenantID, tenantID,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to devicecode",
@@ -536,7 +580,8 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to devicecode, with args as overrides",
@@ -559,7 +604,8 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to devicecode without override",
@@ -579,7 +625,8 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to devicecode with --legacy",
@@ -603,7 +650,8 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig using devicecode and --legacy, convert to devicecode should still have --legacy",
@@ -628,7 +676,8 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to azurecli",
@@ -648,7 +697,8 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to azurecli with --token-cache-dir override",
@@ -670,7 +720,8 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTokenCacheDir, tokenCacheDir,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig already having --token-cache-dir, convert from devicecode to azurecli",
@@ -692,7 +743,8 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTokenCacheDir, tokenCacheDir,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn",
@@ -715,7 +767,8 @@ func TestConvert(t *testing.T) {
 				argClientID, clientID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn without setting environment",
@@ -736,7 +789,8 @@ func TestConvert(t *testing.T) {
 				argClientID, clientID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn with clientID",
@@ -760,7 +814,8 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn with --legacy",
@@ -786,7 +841,8 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to msi",
@@ -806,7 +862,8 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to msi with clientID override",
@@ -828,7 +885,8 @@ func TestConvert(t *testing.T) {
 				argClientID, spClientID,
 				argLoginMethod, token.MSILogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to msi with identity-resource-id override",
@@ -850,7 +908,8 @@ func TestConvert(t *testing.T) {
 				argIdentityResourceID, identityResourceID,
 				argLoginMethod, token.MSILogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to ropc",
@@ -873,7 +932,8 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to ropc with --legacy",
@@ -898,7 +958,8 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.ROPCLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to ropc with username and password",
@@ -925,7 +986,8 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to workload identity",
@@ -945,7 +1007,8 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to workload identity with override",
@@ -973,7 +1036,8 @@ func TestConvert(t *testing.T) {
 				argFederatedTokenFile, federatedTokenFile,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to interactive",
@@ -996,7 +1060,8 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.InteractiveLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to interactive without setting environment",
@@ -1017,7 +1082,8 @@ func TestConvert(t *testing.T) {
 				argClientID, clientID,
 				argLoginMethod, token.InteractiveLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to interactive with override",
@@ -1044,7 +1110,8 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.InteractiveLogin,
 			},
-			command: execName,
+			expectedInstallHint: execInstallHint,
+			command:             execName,
 		},
 		{
 			name: "convert with context specified, auth info not specified by the context should not be changed",
@@ -1064,6 +1131,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
+			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "convert with non-existent context specified, Convert should return error",
@@ -1105,6 +1173,7 @@ func TestConvert(t *testing.T) {
 					Value: azureCLIDir,
 				},
 			},
+			expectedInstallHint: execInstallHint,
 		},
 	}
 	rootTmpDir, err := os.MkdirTemp("", "kubelogin-test")
@@ -1162,13 +1231,13 @@ func TestConvert(t *testing.T) {
 			if o.context != "" {
 				// when --context is specified, convert-kubeconfig will convert only the targeted context
 				// hence, we expect the second auth info not to change
-				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv, data.expectedInstallHint)
 				validateAuthInfoThatShouldNotChange(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig)
 			} else {
 				// when --context is not specified, convert-kubeconfig will convert every auth info in the kubeconfig
 				// hence, we expect the second auth info to be converted in the same way as the first one
-				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
-				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv, data.expectedInstallHint)
+				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs, data.expectedEnv, data.expectedInstallHint)
 			}
 		})
 	}
@@ -1220,6 +1289,7 @@ func validate(
 	authProviderConfig map[string]string,
 	expectedArgs []string,
 	expectedEnv []clientcmdapi.ExecEnvVar,
+	expectedInstallHint string,
 ) {
 	if expectedArgs == nil {
 		if authInfo.AuthProvider == nil {
@@ -1247,8 +1317,8 @@ func validate(
 		t.Fatalf("[context:%s]: expected API Version: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
 	}
 
-	if exec.InstallHint != execInstallHint {
-		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, execInstallHint, exec.InstallHint)
+	if exec.InstallHint != expectedInstallHint {
+		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, expectedInstallHint, exec.InstallHint)
 	}
 
 	if exec.Args[0] != getTokenCommand {

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -34,19 +34,17 @@ func TestConvert(t *testing.T) {
 		azureCLIDir        = "/tmp/foo"
 	)
 	testData := []struct {
-		name                string
-		authProviderConfig  map[string]string
-		overrideFlags       map[string]string
-		expectedArgs        []string
-		execArgItems        []string
-		command             string
-		expectedError       string
-		expectedEnv         []clientcmdapi.ExecEnvVar
-		expectedInstallHint string
+		name               string
+		authProviderConfig map[string]string
+		overrideFlags      map[string]string
+		expectedArgs       []string
+		execArgItems       []string
+		command            string
+		expectedError      string
+		expectedEnv        []clientcmdapi.ExecEnvVar
 	}{
 		{
-			name:                "non azure kubeconfig",
-			expectedInstallHint: execInstallHint,
+			name: "non azure kubeconfig",
 		},
 		{
 			name: "using legacy azure auth to convert to msi",
@@ -65,7 +63,6 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to msi with client-id override",
@@ -86,7 +83,6 @@ func TestConvert(t *testing.T) {
 				argClientID, "msi-client-id",
 				argLoginMethod, token.MSILogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to workload identity",
@@ -105,7 +101,6 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to workload identity with overrides",
@@ -132,7 +127,6 @@ func TestConvert(t *testing.T) {
 				argFederatedTokenFile, federatedTokenFile,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn without setting environment",
@@ -153,7 +147,6 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn with clientSecret",
@@ -178,7 +171,6 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn with clientCert",
@@ -203,7 +195,6 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to spn with password-protected clientCert",
@@ -230,7 +221,6 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to ropc",
@@ -252,7 +242,6 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to ropc with username and password",
@@ -278,7 +267,6 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to azurecli",
@@ -297,7 +285,6 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to azurecli with --tenant-id override",
@@ -318,7 +305,6 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTenantID, tenantID,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert to azurecli with --token-cache-dir override",
@@ -339,27 +325,6 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTokenCacheDir, tokenCacheDir,
 			},
-			expectedInstallHint: execInstallHint,
-		},
-		{
-			name: "using legacy azure auth to convert to azurecli with --install-hint override",
-			authProviderConfig: map[string]string{
-				cfgEnvironment: envName,
-				cfgApiserverID: serverID,
-				cfgClientID:    clientID,
-				cfgTenantID:    tenantID,
-				cfgConfigMode:  "1",
-			},
-			overrideFlags: map[string]string{
-				flagLoginMethod:     token.AzureCLILogin,
-				flagExecInstallHint: "Custom Install Hint",
-			},
-			expectedArgs: []string{
-				getTokenCommand,
-				argServerID, serverID,
-				argLoginMethod, token.AzureCLILogin,
-			},
-			expectedInstallHint: "Custom Install Hint",
 		},
 		{
 			name: "using legacy azure auth to convert to devicecode with redundant arguments",
@@ -391,7 +356,6 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, loginMethod,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth with configMode: \"1\" to convert to devicecode with --legacy",
@@ -415,7 +379,6 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, loginMethod,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth to convert without --login should default to devicecode",
@@ -434,7 +397,6 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth with configMode: \"0\" to convert without --login should default to devicecode",
@@ -454,7 +416,6 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "using legacy azure auth with configMode: \"1\" to convert without --login should result in devicecode without --legacy",
@@ -473,7 +434,6 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli",
@@ -493,8 +453,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli with --tenant-id",
@@ -516,8 +475,7 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTenantID, tenantID,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli, with envName as overrides",
@@ -537,8 +495,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli, with args as overrides",
@@ -558,8 +515,7 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTenantID, tenantID,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to devicecode",
@@ -580,8 +536,7 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to devicecode, with args as overrides",
@@ -604,8 +559,7 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to devicecode without override",
@@ -625,8 +579,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to devicecode with --legacy",
@@ -650,8 +603,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig using devicecode and --legacy, convert to devicecode should still have --legacy",
@@ -676,8 +628,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.DeviceCodeLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to azurecli",
@@ -697,8 +648,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.AzureCLILogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to azurecli with --token-cache-dir override",
@@ -720,8 +670,7 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTokenCacheDir, tokenCacheDir,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig already having --token-cache-dir, convert from devicecode to azurecli",
@@ -743,8 +692,7 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.AzureCLILogin,
 				argTokenCacheDir, tokenCacheDir,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn",
@@ -767,8 +715,7 @@ func TestConvert(t *testing.T) {
 				argClientID, clientID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn without setting environment",
@@ -789,8 +736,7 @@ func TestConvert(t *testing.T) {
 				argClientID, clientID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn with clientID",
@@ -814,8 +760,7 @@ func TestConvert(t *testing.T) {
 				argTenantID, tenantID,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to spn with --legacy",
@@ -841,8 +786,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.ServicePrincipalLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to msi",
@@ -862,8 +806,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to msi with clientID override",
@@ -885,8 +828,7 @@ func TestConvert(t *testing.T) {
 				argClientID, spClientID,
 				argLoginMethod, token.MSILogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to msi with identity-resource-id override",
@@ -908,8 +850,7 @@ func TestConvert(t *testing.T) {
 				argIdentityResourceID, identityResourceID,
 				argLoginMethod, token.MSILogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to ropc",
@@ -932,8 +873,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to ropc with --legacy",
@@ -958,8 +898,7 @@ func TestConvert(t *testing.T) {
 				argIsLegacy,
 				argLoginMethod, token.ROPCLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to ropc with username and password",
@@ -986,8 +925,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.ROPCLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to workload identity",
@@ -1007,8 +945,7 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to workload identity with override",
@@ -1036,8 +973,7 @@ func TestConvert(t *testing.T) {
 				argFederatedTokenFile, federatedTokenFile,
 				argLoginMethod, token.WorkloadIdentityLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to interactive",
@@ -1060,8 +996,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.InteractiveLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to interactive without setting environment",
@@ -1082,8 +1017,7 @@ func TestConvert(t *testing.T) {
 				argClientID, clientID,
 				argLoginMethod, token.InteractiveLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "with exec format kubeconfig, convert from devicecode to interactive with override",
@@ -1110,8 +1044,7 @@ func TestConvert(t *testing.T) {
 				argEnvironment, envName,
 				argLoginMethod, token.InteractiveLogin,
 			},
-			expectedInstallHint: execInstallHint,
-			command:             execName,
+			command: execName,
 		},
 		{
 			name: "convert with context specified, auth info not specified by the context should not be changed",
@@ -1131,7 +1064,6 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
-			expectedInstallHint: execInstallHint,
 		},
 		{
 			name: "convert with non-existent context specified, Convert should return error",
@@ -1173,7 +1105,6 @@ func TestConvert(t *testing.T) {
 					Value: azureCLIDir,
 				},
 			},
-			expectedInstallHint: execInstallHint,
 		},
 	}
 	rootTmpDir, err := os.MkdirTemp("", "kubelogin-test")
@@ -1231,13 +1162,13 @@ func TestConvert(t *testing.T) {
 			if o.context != "" {
 				// when --context is specified, convert-kubeconfig will convert only the targeted context
 				// hence, we expect the second auth info not to change
-				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv, data.expectedInstallHint)
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
 				validateAuthInfoThatShouldNotChange(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig)
 			} else {
 				// when --context is not specified, convert-kubeconfig will convert every auth info in the kubeconfig
 				// hence, we expect the second auth info to be converted in the same way as the first one
-				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv, data.expectedInstallHint)
-				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs, data.expectedEnv, data.expectedInstallHint)
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
+				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
 			}
 		})
 	}
@@ -1289,7 +1220,6 @@ func validate(
 	authProviderConfig map[string]string,
 	expectedArgs []string,
 	expectedEnv []clientcmdapi.ExecEnvVar,
-	expectedInstallHint string,
 ) {
 	if expectedArgs == nil {
 		if authInfo.AuthProvider == nil {
@@ -1317,8 +1247,8 @@ func validate(
 		t.Fatalf("[context:%s]: expected API Version: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
 	}
 
-	if exec.InstallHint != expectedInstallHint {
-		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, expectedInstallHint, exec.InstallHint)
+	if exec.InstallHint != execInstallHint {
+		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, execInstallHint, exec.InstallHint)
 	}
 
 	if exec.Args[0] != getTokenCommand {

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -1244,7 +1244,11 @@ func validate(
 	}
 
 	if exec.APIVersion != execAPIVersion {
-		t.Fatalf("[context:%s]: expected exec command: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
+		t.Fatalf("[context:%s]: expected API Version: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
+	}
+
+	if exec.InstallHint != execInstallHint {
+		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, execInstallHint, exec.InstallHint)
 	}
 
 	if exec.Args[0] != getTokenCommand {

--- a/pkg/converter/convert_test.go
+++ b/pkg/converter/convert_test.go
@@ -34,17 +34,33 @@ func TestConvert(t *testing.T) {
 		azureCLIDir        = "/tmp/foo"
 	)
 	testData := []struct {
-		name               string
-		authProviderConfig map[string]string
-		overrideFlags      map[string]string
-		expectedArgs       []string
-		execArgItems       []string
-		command            string
-		expectedError      string
-		expectedEnv        []clientcmdapi.ExecEnvVar
+		name                string
+		authProviderConfig  map[string]string
+		overrideFlags       map[string]string
+		expectedArgs        []string
+		execArgItems        []string
+		command             string
+		expectedExecName    string
+		installHint         string
+		expectedInstallHint string
+		expectedError       string
+		expectedEnv         []clientcmdapi.ExecEnvVar
 	}{
 		{
 			name: "non azure kubeconfig",
+		},
+		{
+			name:             "non azure kubeconfig in exec format with install hint",
+			command:          "foo",
+			expectedExecName: "foo",
+			execArgItems: []string{
+				"--bar",
+			},
+			expectedArgs: []string{
+				"--bar",
+			},
+			installHint:         "foo install hint",
+			expectedInstallHint: "foo install hint",
 		},
 		{
 			name: "using legacy azure auth to convert to msi",
@@ -63,6 +79,25 @@ func TestConvert(t *testing.T) {
 				argServerID, serverID,
 				argLoginMethod, token.MSILogin,
 			},
+		},
+		{
+			name: "using legacy azure auth to convert to msi will overwrite install hint",
+			authProviderConfig: map[string]string{
+				cfgEnvironment: envName,
+				cfgApiserverID: serverID,
+				cfgClientID:    clientID,
+				cfgTenantID:    tenantID,
+				cfgConfigMode:  "0",
+			},
+			overrideFlags: map[string]string{
+				flagLoginMethod: token.MSILogin,
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argLoginMethod, token.MSILogin,
+			},
+			installHint: "Overwrite this install hint",
 		},
 		{
 			name: "using legacy azure auth to convert to msi with client-id override",
@@ -456,6 +491,28 @@ func TestConvert(t *testing.T) {
 			command: execName,
 		},
 		{
+			name: "with exec format kubeconfig, convert from azurecli to azurecli with existing install hint",
+			execArgItems: []string{
+				getTokenCommand,
+				argEnvironment, envName,
+				argServerID, serverID,
+				argClientID, clientID,
+				argTenantID, tenantID,
+				argLoginMethod, token.AzureCLILogin,
+			},
+			overrideFlags: map[string]string{
+				flagLoginMethod: token.AzureCLILogin,
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argLoginMethod, token.AzureCLILogin,
+			},
+			command:             execName,
+			installHint:         "Preserve this install hint",
+			expectedInstallHint: "Preserve this install hint",
+		},
+		{
 			name: "with exec format kubeconfig, convert from azurecli to azurecli with --tenant-id",
 			execArgItems: []string{
 				getTokenCommand,
@@ -537,6 +594,29 @@ func TestConvert(t *testing.T) {
 				argLoginMethod, token.DeviceCodeLogin,
 			},
 			command: execName,
+		},
+		{
+			name: "with exec format kubeconfig, convert from azurecli to devicecode with existing install hint",
+			execArgItems: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argLoginMethod, token.AzureCLILogin,
+			},
+			overrideFlags: map[string]string{
+				flagClientID:    clientID,
+				flagTenantID:    tenantID,
+				flagLoginMethod: token.DeviceCodeLogin,
+			},
+			expectedArgs: []string{
+				getTokenCommand,
+				argServerID, serverID,
+				argClientID, clientID,
+				argTenantID, tenantID,
+				argLoginMethod, token.DeviceCodeLogin,
+			},
+			command:             execName,
+			installHint:         "Preserve this install hint",
+			expectedInstallHint: "Preserve this install hint",
 		},
 		{
 			name: "with exec format kubeconfig, convert from azurecli to devicecode, with args as overrides",
@@ -1131,6 +1211,7 @@ func TestConvert(t *testing.T) {
 				authProviderName,
 				data.authProviderConfig,
 				data.execArgItems,
+				data.installHint,
 			)
 			fs := &pflag.FlagSet{}
 			o := Options{
@@ -1162,13 +1243,13 @@ func TestConvert(t *testing.T) {
 			if o.context != "" {
 				// when --context is specified, convert-kubeconfig will convert only the targeted context
 				// hence, we expect the second auth info not to change
-				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedExecName, data.expectedInstallHint, data.expectedEnv)
 				validateAuthInfoThatShouldNotChange(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig)
 			} else {
 				// when --context is not specified, convert-kubeconfig will convert every auth info in the kubeconfig
 				// hence, we expect the second auth info to be converted in the same way as the first one
-				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
-				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs, data.expectedEnv)
+				validate(t, clusterName1, config.AuthInfos[clusterName1], data.authProviderConfig, data.expectedArgs, data.expectedExecName, data.expectedInstallHint, data.expectedEnv)
+				validate(t, clusterName2, config.AuthInfos[clusterName2], data.authProviderConfig, data.expectedArgs, data.expectedExecName, data.expectedInstallHint, data.expectedEnv)
 			}
 		})
 	}
@@ -1178,6 +1259,7 @@ func createValidTestConfigs(
 	name1, name2, commandName, authProviderName string,
 	authProviderConfig map[string]string,
 	execArgItems []string,
+	installHint string,
 ) *clientcmdapi.Config {
 	const server = "https://anything.com:8080"
 
@@ -1190,8 +1272,9 @@ func createValidTestConfigs(
 		if authProviderConfig == nil && execArgItems != nil {
 			config.AuthInfos[name] = &clientcmdapi.AuthInfo{
 				Exec: &clientcmdapi.ExecConfig{
-					Args:    execArgItems,
-					Command: commandName,
+					Args:        execArgItems,
+					Command:     commandName,
+					InstallHint: installHint,
 				},
 			}
 		} else {
@@ -1219,6 +1302,8 @@ func validate(
 	authInfo *clientcmdapi.AuthInfo,
 	authProviderConfig map[string]string,
 	expectedArgs []string,
+	expectedExecName string,
+	expectedInstallHint string,
 	expectedEnv []clientcmdapi.ExecEnvVar,
 ) {
 	if expectedArgs == nil {
@@ -1239,21 +1324,35 @@ func validate(
 		t.Fatalf("[context:%s]: %s", clusterName, "unable to find exec plugin")
 	}
 
-	if exec.Command != execName {
-		t.Fatalf("[context:%s]: expected exec command: %s, actual: %s", clusterName, execName, exec.Command)
+	// default to the kubelogin exec name
+	if expectedExecName == "" {
+		expectedExecName = execName
 	}
 
-	if exec.APIVersion != execAPIVersion {
-		t.Fatalf("[context:%s]: expected API Version: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
+	if exec.Command != expectedExecName {
+		t.Fatalf("[context:%s]: expected exec command: %s, actual: %s", clusterName, expectedExecName, exec.Command)
 	}
 
-	if exec.InstallHint != execInstallHint {
-		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, execInstallHint, exec.InstallHint)
+	// defautl to the kubelogin install hint
+	if expectedInstallHint == "" {
+		expectedInstallHint = execInstallHint
 	}
 
-	if exec.Args[0] != getTokenCommand {
-		t.Fatalf("[context:%s]: expected %s as first argument. actual: %s", clusterName, getTokenCommand, exec.Args[0])
+	if exec.InstallHint != expectedInstallHint {
+		t.Fatalf("[context:%s]: expected install hint: %s, actual: %s", clusterName, expectedInstallHint, exec.InstallHint)
 	}
+
+	// Only validate the API version and first arg if exec is using kubelogin
+	if exec.Command == execName {
+		if exec.APIVersion != execAPIVersion {
+			t.Fatalf("[context:%s]: expected API Version: %s, actual: %s", clusterName, execAPIVersion, exec.APIVersion)
+		}
+
+		if exec.Args[0] != getTokenCommand {
+			t.Fatalf("[context:%s]: expected %s as first argument. actual: %s", clusterName, getTokenCommand, exec.Args[0])
+		}
+	}
+
 	if len(exec.Args) != len(expectedArgs) {
 		t.Fatalf("[context:%s]: expected exec args: %v, actual: %v", clusterName, expectedArgs, exec.Args)
 	}

--- a/pkg/converter/options.go
+++ b/pkg/converter/options.go
@@ -13,8 +13,9 @@ type Options struct {
 	configFlags  genericclioptions.RESTClientGetter
 	TokenOptions token.Options
 	// context is the kubeconfig context name
-	context        string
-	azureConfigDir string
+	context         string
+	azureConfigDir  string
+	execInstallHint string
 }
 
 func stringptr(str string) *string { return &str }
@@ -33,6 +34,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	}
 	fs.StringVar(&o.context, flagContext, "", "The name of the kubeconfig context to use")
 	fs.StringVar(&o.azureConfigDir, flagAzureConfigDir, "", "Azure CLI config path")
+	fs.StringVar(&o.execInstallHint, flagExecInstallHint, "", "The install hint for the kubelogin command when converting to exec format.")
 	o.TokenOptions.AddFlags(fs)
 }
 

--- a/pkg/converter/options.go
+++ b/pkg/converter/options.go
@@ -13,9 +13,8 @@ type Options struct {
 	configFlags  genericclioptions.RESTClientGetter
 	TokenOptions token.Options
 	// context is the kubeconfig context name
-	context         string
-	azureConfigDir  string
-	execInstallHint string
+	context        string
+	azureConfigDir string
 }
 
 func stringptr(str string) *string { return &str }
@@ -34,7 +33,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	}
 	fs.StringVar(&o.context, flagContext, "", "The name of the kubeconfig context to use")
 	fs.StringVar(&o.azureConfigDir, flagAzureConfigDir, "", "Azure CLI config path")
-	fs.StringVar(&o.execInstallHint, flagExecInstallHint, "", "The install hint for the kubelogin command when converting to exec format.")
 	o.TokenOptions.AddFlags(fs)
 }
 


### PR DESCRIPTION
InstallHint field tells users how to install the binary in the command field if it isn't present in their PATH.
We need to add this field to any kubeconfig that gets converted since it can be transported to another machine/environment that does not have kubelogin installed.