### PR TITLE
docs: Use asdf-plugins index instead of hard coded repo

### DIFF
--- a/docs/book/src/install.md
+++ b/docs/book/src/install.md
@@ -23,7 +23,7 @@ _asdf and the asdf-kubelogin plugin are not maintained by Microsoft._
 
 ```sh
 # install
-asdf plugin add kubelogin https://github.com/sechmann/asdf-kubelogin
+asdf plugin add kubelogin
 asdf install kubelogin latest
 asdf global kubelogin latest
 


### PR DESCRIPTION
This makes it less likely these docs will break in the event that this plugin repository moves.