### PR TITLE
Add chocolatey installation instructions

### DIFF
--- a/docs/book/src/install.md
+++ b/docs/book/src/install.md
@@ -55,7 +55,7 @@ From Powershell:
 scoop install kubectl azure-kubelogin
 ```
 
-### Using choco
+### Using chocolatey
 
 This package is not maintained by Microsoft.
 

--- a/docs/book/src/install.md
+++ b/docs/book/src/install.md
@@ -55,6 +55,16 @@ From Powershell:
 scoop install kubectl azure-kubelogin
 ```
 
+### Using choco
+
+This package is not maintained by Microsoft.
+
+From Powershell:
+
+```powershell
+choco install kubernetes-cli azure-kubelogin
+```
+
 ### Using azure cli
 
 From Powershell:


### PR DESCRIPTION
Adding chocolatey installation instructions. They would've helped me as I first confused the package with https://community.chocolatey.org/packages/kubelogin (https://github.com/int128/kubelogin), a different "kubelogin" plugin.

The package seems to not be maintained by MS directly, but neither is the Scoop one, so I added the disclaimer here as well.