### PR TITLE
feat(timeout): Implement customizable timeout for Azure CLI token ret…

### DIFF
--- a/pkg/token/azurecli_test.go
+++ b/pkg/token/azurecli_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestNewAzureCLITokenEmpty(t *testing.T) {
-	_, err := newAzureCLIToken("", "")
+	// Using default timeout for testing
+	_, err := newAzureCLIToken("", "", defaultTimeout)
 
 	if !testutils.ErrorContains(err, "resourceID cannot be empty") {
 		t.Errorf("unexpected error: %v", err)
@@ -20,5 +21,31 @@ func TestNewAzureCLIToken(t *testing.T) {
 
 	if !testutils.ErrorContains(err, "expected an empty error but received:") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestOptionsValidateTimeout(t *testing.T) {
+	// Assuming "devicecode" is a valid login method based on your error message
+	validLoginMethod := "devicecode"
+
+	// Test with Timeout set to 0
+	options := Options{LoginMethod: validLoginMethod, Timeout: 0}
+	err := options.Validate()
+	if !testutils.ErrorContains(err, "timeout must be greater than 0") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+
+	// Test with Timeout set to a negative value
+	options = Options{LoginMethod: validLoginMethod, Timeout: -1}
+	err = options.Validate()
+	if !testutils.ErrorContains(err, "timeout must be greater than 0") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+
+	// Test with a valid Timeout value
+	options = Options{LoginMethod: validLoginMethod, Timeout: 10}
+	err = options.Validate()
+	if err != nil {
+		t.Errorf("unexpected error for valid timeout: %v", err)
 	}
 }

--- a/pkg/token/options_test.go
+++ b/pkg/token/options_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/kubelogin/pkg/testutils"
 	"github.com/google/go-cmp/cmp"
@@ -104,6 +105,7 @@ func TestOptionsWithEnvVars(t *testing.T) {
 				TenantID:           tenantID,
 				LoginMethod:        DeviceCodeLogin,
 				tokenCacheFile:     "---.json",
+				Timeout:            30 * time.Second,
 			},
 		},
 		{
@@ -126,6 +128,7 @@ func TestOptionsWithEnvVars(t *testing.T) {
 				TenantID:               tenantID,
 				LoginMethod:            DeviceCodeLogin,
 				tokenCacheFile:         "---.json",
+				Timeout:                30 * time.Second,
 			},
 		},
 		{
@@ -154,6 +157,7 @@ func TestOptionsWithEnvVars(t *testing.T) {
 				AuthorityHost:      authorityHost,
 				FederatedTokenFile: tokenFile,
 				tokenCacheFile:     "---.json",
+				Timeout:            30 * time.Second,
 			},
 		},
 	}

--- a/pkg/token/provider.go
+++ b/pkg/token/provider.go
@@ -43,7 +43,7 @@ func newTokenProvider(o *Options) (TokenProvider, error) {
 	case MSILogin:
 		return newManagedIdentityToken(o.ClientID, o.IdentityResourceID, o.ServerID)
 	case AzureCLILogin:
-		return newAzureCLIToken(o.ServerID, o.TenantID)
+		return newAzureCLIToken(o.ServerID, o.TenantID, o.Timeout)
 	case WorkloadIdentityLogin:
 		return newWorkloadIdentityToken(o.ClientID, o.FederatedTokenFile, o.AuthorityHost, o.ServerID, o.TenantID)
 	}


### PR DESCRIPTION
This commit introduces the ability to specify a custom timeout for Azure CLI token retrieval within the kubelogin package. The `AzureCLIToken` struct now includes a `timeout` field, allowing users to set a specific timeout duration.