### PR TITLE
Default branch is now main.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - README.md
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - docs/**
       - README.md

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,13 +13,13 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths-ignore:
       - docs/**
       - README.md
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "main" ]
     paths-ignore:
       - docs/**
       - README.md

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,6 @@ on:
     tags:
       - v*
     branches:
-      - master
       - main
     paths-ignore:
       - docs/**

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -3,7 +3,7 @@ name: generate github pages
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - ".github/workflows/website.yaml"
       - "docs/**"
@@ -31,7 +31,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book/book

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![golangci-lint](https://github.com/Azure/kubelogin/actions/workflows/golangci-lint.yml/badge.svg)](https://github.com/Azure/kubelogin/actions/workflows/golangci-lint.yml)
 [![Build on Push](https://github.com/Azure/kubelogin/actions/workflows/build.yml/badge.svg)](https://github.com/Azure/kubelogin/actions/workflows/build.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Azure/kubelogin.svg)](https://pkg.go.dev/github.com/Azure/kubelogin)
-[![codecov](https://codecov.io/gh/Azure/kubelogin/branch/master/graph/badge.svg?token=02PZRX59VM)](https://codecov.io/gh/Azure/kubelogin)
+[![codecov](https://codecov.io/gh/Azure/kubelogin/branch/main/graph/badge.svg?token=02PZRX59VM)](https://codecov.io/gh/Azure/kubelogin)
 
 This is a [client-go credential (exec) plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) implementing azure authentication. This plugin provides features that are not available in kubectl. It is supported on kubectl v1.11+
 

--- a/docs/book/src/topics/environments.md
+++ b/docs/book/src/topics/environments.md
@@ -46,4 +46,4 @@ The configuration parameters of this file:
 }
 ```
 
-The full configuration is available in the source code at <https://github.com/Azure/go-autorest/blob/master/autorest/azure/environments.go>.
+The full configuration is available in the source code at <https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go>.


### PR DESCRIPTION
Thank you so much for the role elevation @weinong  , the default branch is now `main`, which inturn take care of #389 ❤️🙏🥷

* This PR updates the relevant workflows to point to `main` instead of `master` branch for this repo. 🚀🛺

* For Local update folks can follow this: [updating-a-local-clone-after-a-branch-name-changes](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch#updating-a-local-clone-after-a-branch-name-changes)

* CodeCov is also taken care of and default branch is now `main`

Here are few screenshot and for local rename of branch how to quick command:

```*.git
git branch -m master main
git fetch origin
git branch -u main main
git remote set-head origin -a
```

<img width="637" alt="Screenshot 2023-12-30 at 9 59 48 AM" src="https://github.com/Azure/kubelogin/assets/6233295/d89d9043-100c-4d85-a890-c90fd8ba993e">

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdjltNXR1aXA1eHFxMWJpM3R3cHc0cHRiNXFkeHVxbTNyYzFraDFxYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/11pEf1ZMBCxoe4/giphy.gif)
