### PR TITLE
Changes in correlation with new GH Action Permission Changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     env:
       GO111MODULE: on
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,6 +20,11 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      deployments: read
+      packages: none
     env:
       GO111MODULE: on
     steps:


### PR DESCRIPTION
These changes are made in correlation with the following changes coming soon in the GH actions permissions. Please take a kind look. ❤️🙏☕️

* https://docs.opensource.microsoft.com/github/apps/permission-changes/

To start with going with the most safest option with read only permission, for `publish` we need the `write for content`. Given this will spread pretty soon lets try this out and I will gradually open similarity changes in other repos I know.

<img width="676" alt="Screenshot 2024-01-22 at 11 41 38 AM" src="https://github.com/Azure/vscode-bridge-to-kubernetes/assets/6233295/5106db83-6dcd-41ac-942a-90a03cfaac96">

For **Sample test** if we do `content: read` (In a separate **repo**) for publish we will get some error like this which I tested in my fork for other project.

<img width="1714" alt="Screenshot 2024-01-22 at 11 27 19 AM" src="https://github.com/Azure/vscode-bridge-to-kubernetes/assets/6233295/b00462d5-d971-43d2-9c06-0d7c65f6b91c">

Thank you. ❤️🙏
