### PR TITLE
chore: upgrade go to v1.21.11 to fix CVE-2024-24790

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/Azure/kubelogin
 
 // NOTE: kubelogin follows the same support policy as Go, which supports the last two major versions.
-go 1.21.9
+go 1.21.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0


### PR DESCRIPTION
Upgrade Go to `v1.2.11` to fix CVE-2024-24790. The CVE was fixed in the following commit: https://go-review.googlesource.com/c/go/+/590315 which was released in the `v1.2.11` release of Go.