### PR TITLE
support of environment variable KUBECACHEDIR #500

### DIFF
--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -63,13 +63,16 @@ func GetSupportedLogins() string {
 }
 
 func NewOptions() Options {
-	if env_TokenCacheDir := os.Getenv("KUBECACHEDIR"); env_TokenCacheDir != "" {
-		DefaultTokenCacheDir = env_TokenCacheDir
-	}
+	env_TokenCacheDir := os.Getenv("KUBECACHEDIR")
 	return Options{
-		LoginMethod:   DeviceCodeLogin,
-		Environment:   defaultEnvironmentName,
-		TokenCacheDir: DefaultTokenCacheDir,
+		LoginMethod: DeviceCodeLogin,
+		Environment: defaultEnvironmentName,
+		TokenCacheDir: func() string {
+			if env_TokenCacheDir != "" {
+				return env_TokenCacheDir
+			}
+			return DefaultTokenCacheDir
+		}(),
 	}
 }
 

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -63,16 +63,13 @@ func GetSupportedLogins() string {
 }
 
 func NewOptions() Options {
-	env_TokenCacheDir := os.Getenv("KUBECACHEDIR")
+	if env_TokenCacheDir := os.Getenv("KUBECACHEDIR"); env_TokenCacheDir != "" {
+		DefaultTokenCacheDir = env_TokenCacheDir
+	}
 	return Options{
-		LoginMethod: DeviceCodeLogin,
-		Environment: defaultEnvironmentName,
-		TokenCacheDir: func() string {
-			if env_TokenCacheDir != "" {
-				return env_TokenCacheDir
-			}
-			return DefaultTokenCacheDir
-		}(),
+		LoginMethod:   DeviceCodeLogin,
+		Environment:   defaultEnvironmentName,
+		TokenCacheDir: DefaultTokenCacheDir,
 	}
 }
 

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -63,10 +63,16 @@ func GetSupportedLogins() string {
 }
 
 func NewOptions() Options {
+	env_TokenCacheDir := os.Getenv("KUBECACHEDIR")
 	return Options{
-		LoginMethod:   DeviceCodeLogin,
-		Environment:   defaultEnvironmentName,
-		TokenCacheDir: DefaultTokenCacheDir,
+		LoginMethod: DeviceCodeLogin,
+		Environment: defaultEnvironmentName,
+		TokenCacheDir: func() string {
+			if env_TokenCacheDir != "" {
+				return env_TokenCacheDir
+			}
+			return DefaultTokenCacheDir
+		}(),
 	}
 }
 

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -63,13 +63,13 @@ func GetSupportedLogins() string {
 }
 
 func NewOptions() Options {
-	env_TokenCacheDir := os.Getenv("KUBECACHEDIR")
+	envTokenCacheDir := os.Getenv("KUBECACHEDIR")
 	return Options{
 		LoginMethod: DeviceCodeLogin,
 		Environment: defaultEnvironmentName,
 		TokenCacheDir: func() string {
-			if env_TokenCacheDir != "" {
-				return env_TokenCacheDir
+			if envTokenCacheDir != "" {
+				return envTokenCacheDir
 			}
 			return DefaultTokenCacheDir
 		}(),


### PR DESCRIPTION
Fix to support environment variable KUBECACHEDIR, already supported by kubectl, to change the location of folder `~/.kube/cache`.
This is necessary to support having different environments using different Azure identities.