### PR TITLE
Use AZURE_CONFIG_DIR in kubelogin command example

### DIFF
--- a/docs/book/src/topics/jenkins.md
+++ b/docs/book/src/topics/jenkins.md
@@ -12,7 +12,7 @@ Using kubelogin `convert-kubeconfig` subcommand with `--azure-config-dir`, the g
 stage('Download kubeconfig and convert') {
     steps {
         sh 'az aks get-credentials -g ${RESOURCE_GROUP} -n ${CLUSTER_NAME}'
-        sh 'kubelogin convert-kubeconfig -l azurecli --azure-config-dir ${WORKSPACE}/.azure'
+        sh 'kubelogin convert-kubeconfig -l azurecli --azure-config-dir ${AZURE_CONFIG_DIR}'
     }
 }
 

--- a/docs/book/src/topics/jenkins.md
+++ b/docs/book/src/topics/jenkins.md
@@ -12,7 +12,7 @@ Using kubelogin `convert-kubeconfig` subcommand with `--azure-config-dir`, the g
 stage('Download kubeconfig and convert') {
     steps {
         sh 'az aks get-credentials -g ${RESOURCE_GROUP} -n ${CLUSTER_NAME}'
-        sh 'kubelogin convert-kubeconfig -l azurecli --azure-config-dir ${AZURE_CONFIG_DIR}'
+        sh 'kubelogin convert-kubeconfig -l azurecli --azure-config-dir ${AZURE_CONFIG_DIR:-${WORKSPACE}/.azure}'
     }
 }
 


### PR DESCRIPTION
When calling `kubelogin` with `AZURE_CONFIG_DIR` already set in a Jenkins job, just use that variable on the command line for consistency with the variable Jenkins is using, instead of doing `$WORKSPACE/.azure` which might not be where AZURE_CONFIG_DIR points to.