### PR TITLE
fix: fix fallback to Git tag if VCS is unavailable

### DIFF
--- a/version.go
+++ b/version.go
@@ -60,7 +60,7 @@ func loadVersion() Version {
 	// ref: https://github.com/golang/go/issues/51279
 	// Fallback to use module version and stop here as vcs information is incomplete.
 	if revision == "" {
-		if buildInfo.Main.Version != "" {
+		if buildInfo.Main.Version != "(devel)" {
 			// fallback to use module version (legacy usage)
 			rv.Version = buildInfo.Main.Version
 		}


### PR DESCRIPTION
When version is unavailable from the VCS, build info always returns `(devel)` as version

Tested without `.git` directory:

```console
$ make kubelogin GIT_TAG=v0.1.4
rm -f bin/darwin_arm64/kubelogin
CGO_ENABLED=0 go build -o bin/darwin_arm64/kubelogin -ldflags "-X main.gitTag=v0.1.4"

$ "bin/$(go env GOOS)_$(go env GOARCH)/kubelogin" --version
kubelogin version
git hash: v0.1.4
Go version: go1.23.1
Build time: unknown
Platform: darwin/arm64
```