### PR TITLE
Preemptive fix for the breaking GH Action.

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,7 +58,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Following PR will take care of this Breaking change for `upload-artifact` https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#artifacts-v3-brownouts 

Hence moved to latest `v4` release and pinned it to the commit.

Thanks heaps and gentle fyi to @weinong + @bcho 

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2xzaXZueW1yOTl2N3VvMHduOHF1dXk2amUyNzNzc2s4ZXE0eWg3NCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/FP7g0JkFYO4gK9o4vr/giphy.gif)