### PR TITLE
Add x5c Header when Acquiring PoP Tokens

### DIFF
--- a/pkg/internal/pop/msal_confidential.go
+++ b/pkg/internal/pop/msal_confidential.go
@@ -42,12 +42,14 @@ func AcquirePoPTokenConfidential(
 			clientID,
 			cred,
 			confidential.WithHTTPClient(options.Transport.(*http.Client)),
+			confidential.WithX5C(),
 		)
 	} else {
 		client, err = confidential.New(
 			authority,
 			clientID,
 			cred,
+			confidential.WithX5C(),
 		)
 	}
 	if err != nil {


### PR DESCRIPTION
If an SPN uses an SNI certificate for authentication, the x5c header must be included in the request. Omitting this header will cause the authentication call to fail. However, if the credentials are not a certificate, no error occurs, and the process continues without issues.

Failing call: 
[Pipeline Run](https://dev.azure.com/msazure/AzureArcPlatform/_build/results?buildId=109555086&view=logs&j=2abc48de-4353-5466-8845-7034719c40d5&t=92649510-3cc4-5340-466a-08fee57f1a27) 

Error:
AADSTS700027: The certificate with the identifier used to sign the client assertion is not registered on the application. [Reason: The key was not found.] Thumbprint of the key used by the client: <thumbprint>

Successful Run with Fix Applied:
[Pipeline Run](https://dev.azure.com/msazure/AzureArcPlatform/_build/results?buildId=109790643&view=results)