### PR TITLE
feat: add himds token provider

### DIFF
--- a/pkg/internal/token/himds.go
+++ b/pkg/internal/token/himds.go
@@ -1,0 +1,146 @@
+package token
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+)
+
+const (
+	defaultIdentityEndpoint = "http://127.0.0.1:40342/metadata/identity/oauth2/token"
+)
+
+// HIMDSToken is a struct that implements the TokenProvider interface to return a token using the HIMDS service.
+type HIMDSToken struct {
+	httpClient *http.Client
+	apiVersion string
+	serverID   string
+
+	identityEndpoint string
+}
+
+// newHIMDSToken creates a new HIMDSToken instance which implements the TokenProvider interface.
+func newHIMDSToken(serverID, apiVersion, identityEndpoint string) (HIMDSToken, error) {
+	himdsEndpoint := identityEndpoint
+	if himdsEndpoint == "" {
+		himdsEndpoint = defaultIdentityEndpoint
+	}
+
+	return HIMDSToken{
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		apiVersion:       apiVersion,
+		serverID:         serverID,
+		identityEndpoint: himdsEndpoint,
+	}, nil
+}
+
+// Token implements the TokenProvider interface to return a token using the HIMDS service.
+func (h HIMDSToken) Token(ctx context.Context) (adal.Token, error) {
+	challengeTokenPath, err := getChallengeTokenPath(
+		ctx,
+		h.httpClient,
+		h.identityEndpoint,
+		h.apiVersion,
+		h.serverID,
+	)
+	if err != nil {
+		return adal.Token{}, fmt.Errorf("failed to get challenge token path: %w", err)
+	}
+
+	if challengeTokenPath == "" {
+		return adal.Token{}, fmt.Errorf("challenge token path is empty")
+	}
+
+	return getBearerToken(ctx, h.httpClient, h.identityEndpoint, challengeTokenPath, h.apiVersion, h.serverID)
+}
+
+// getChallengeTokenPath  returns the challenge token path from the HIMDS service.
+func getChallengeTokenPath(
+	ctx context.Context,
+	httpClient *http.Client,
+	identityEndpoint, apiVersion, resource string,
+) (string, error) {
+	// Create the request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, identityEndpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create himds request: %w", err)
+	}
+
+	// Add the required query parameters
+	req.Header.Set("Metadata", "true")
+	q := req.URL.Query()
+	q.Add("api-version", apiVersion)
+	q.Add("resource", resource)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send himds token request: %w", err)
+	}
+
+	return extractTokenPath(resp.Header.Get("Www-Authenticate"))
+}
+
+// extractTokenPath extracts the token path from the WWW-Authenticate header.
+func extractTokenPath(authHeader string) (string, error) {
+	const prefix = "Basic realm="
+	if len(authHeader) < len(prefix) {
+		return "", fmt.Errorf("invalid auth header")
+	}
+
+	return strings.TrimPrefix(authHeader, prefix), nil
+}
+
+func getBearerToken(
+	ctx context.Context,
+	httpClient *http.Client,
+	identityEndpoint, challengeTokenPath, apiVersion, resource string,
+) (adal.Token, error) {
+	// Create the request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, identityEndpoint, nil)
+	if err != nil {
+		return adal.Token{}, fmt.Errorf("failed to create himds request: %w", err)
+	}
+
+	if challengeTokenPath == "" {
+		return adal.Token{}, fmt.Errorf("challenge token path is empty")
+	}
+
+	challengeToken, err := os.ReadFile(challengeTokenPath)
+	if err != nil {
+		return adal.Token{}, fmt.Errorf("failed to read challenge token: %w", err)
+	}
+
+	// Add challenge token path to the request
+	req.Header.Set("Metadata", "true")
+	req.Header.Set("Authorization", "Basic "+string(challengeToken))
+
+	// Add the required query parameters
+	q := req.URL.Query()
+	q.Add("api-version", apiVersion)
+	q.Add("resource", resource)
+	req.URL.RawQuery = q.Encode()
+
+	// Send the request
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return adal.Token{}, fmt.Errorf("failed to send himds token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Parse the response
+	var t adal.Token
+	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
+		return adal.Token{}, fmt.Errorf("failed to decode himds token response: %w", err)
+	}
+
+	return t, nil
+
+}

--- a/pkg/internal/token/himds_test.go
+++ b/pkg/internal/token/himds_test.go
@@ -1,0 +1,304 @@
+package token
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testServerID   = "serverID"
+	testAPIVersion = "2021-02-01"
+	testTokenPath  = "/var/opt/azcmagent/tokens/fake.key"
+)
+
+func TestNewHIMDSToken(t *testing.T) {
+	testCases := []struct {
+		name             string
+		identityEndpoint string
+		expectedEndpoint string
+		serverID         string
+		apiVersion       string
+	}{
+		{
+			name:             "default identity endpoint",
+			identityEndpoint: "",
+			expectedEndpoint: defaultIdentityEndpoint,
+			serverID:         testServerID,
+			apiVersion:       testAPIVersion,
+		},
+		{
+			name:             "custom identity endpoint",
+			identityEndpoint: "http://127.0.0.1:8080/metadata/identity/oauth2/token",
+			expectedEndpoint: "http://127.0.0.1:8080/metadata/identity/oauth2/token",
+			serverID:         testServerID,
+			apiVersion:       testAPIVersion,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, err := newHIMDSToken(tc.serverID, tc.apiVersion, tc.identityEndpoint)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.apiVersion, h.apiVersion)
+			assert.Equal(t, tc.serverID, h.serverID)
+			assert.Equal(t, tc.expectedEndpoint, h.identityEndpoint)
+			assert.NotNil(t, h.httpClient)
+		})
+	}
+}
+
+func TestHIMDSToken(t *testing.T) {
+	testCases := []struct {
+		name          string
+		challengePath string
+		tokenResponse string
+		svrURL        string
+		expectedToken adal.Token
+		expectErr     bool
+	}{
+		{
+			name:          "valid response",
+			svrURL:        "",
+			challengePath: path.Join(t.TempDir(), "fake.key"),
+			tokenResponse: `{"access_token":"accessToken","refresh_token":"refreshToken","expires_on":84245, "not_before":"1733696828", "resource": "serverID", "token_type":"Bearer"}`,
+			expectedToken: adal.Token{
+				AccessToken:  "accessToken",
+				RefreshToken: "refreshToken",
+				ExpiresOn:    json.Number("84245"),
+				NotBefore:    json.Number("1733696828"),
+				Resource:     testServerID,
+				Type:         "Bearer",
+			},
+		},
+		{
+			name:          "invalid header",
+			svrURL:        "",
+			challengePath: "invalid",
+			tokenResponse: "",
+			expectedToken: adal.Token{},
+			expectErr:     true,
+		},
+		{
+			name:          "empty challenge token path",
+			svrURL:        "",
+			challengePath: "",
+			tokenResponse: "",
+			expectedToken: adal.Token{},
+			expectErr:     true,
+		},
+		{
+			name:          "client error",
+			svrURL:        "http://invalid", // simulates client error
+			challengePath: path.Join(t.TempDir(), "fake.key"),
+			tokenResponse: `{"access_token":"accessToken","refresh_token":"refreshToken","expires_on":84245, "not_before":"1733696828", "resource": "serverID", "token_type":"Bearer"}`,
+			expectedToken: adal.Token{},
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Www-Authenticate", "Basic realm="+tc.challengePath)
+
+				if tc.tokenResponse != "" {
+					w.Write([]byte(tc.tokenResponse))
+				}
+			}))
+			defer srv.Close()
+
+			url := srv.URL
+			if tc.svrURL != "" {
+				url = tc.svrURL
+			}
+
+			h := HIMDSToken{
+				httpClient:       srv.Client(),
+				apiVersion:       testAPIVersion,
+				serverID:         testServerID,
+				identityEndpoint: url,
+			}
+
+			// Write the test token in the challenge path
+			if tc.challengePath != "" && tc.challengePath != "invalid" {
+				err := os.WriteFile(tc.challengePath, []byte("accessToken"), 0644)
+				require.NoError(t, err)
+			}
+
+			token, err := h.Token(context.Background())
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedToken, token)
+		})
+	}
+}
+
+func TestGetChallengePath(t *testing.T) {
+	testCases := []struct {
+		name         string
+		handler      http.HandlerFunc
+		servURL      string
+		expectedPath string
+		expectErr    bool
+	}{
+		{
+			name: "valid response",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Www-Authenticate", "Basic realm="+testTokenPath)
+			},
+			servURL:      "",
+			expectedPath: testTokenPath,
+			expectErr:    false,
+		},
+		{
+			name: "invalid header",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Www-Authenticate", "invalid")
+			},
+			servURL:      "",
+			expectedPath: "",
+			expectErr:    true,
+		},
+		{
+			name: "client error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Www-Authenticate", "Basic realm="+testTokenPath)
+			},
+			servURL:      "http://invalid", // simulates client error
+			expectedPath: "",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			url := srv.URL
+			if tc.servURL != "" {
+				url = tc.servURL
+			}
+
+			challengeTokenPath, err := getChallengeTokenPath(
+				context.Background(),
+				srv.Client(),
+				url,
+				testAPIVersion,
+				testServerID,
+			)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedPath, challengeTokenPath)
+		})
+	}
+}
+
+func TestGetBearerToken(t *testing.T) {
+	testCases := []struct {
+		name          string
+		challengePath string
+		tokenResponse string
+		servURL       string
+		expectedToken adal.Token
+		expectErr     bool
+	}{
+		{
+			name:          "valid response",
+			tokenResponse: `{"access_token":"accessToken","refresh_token":"refreshToken","expires_on":84245, "not_before":"1733696828", "resource": "serverID", "token_type":"Bearer"}`,
+			challengePath: path.Join(t.TempDir(), "fake.key"),
+			servURL:       "",
+			expectedToken: adal.Token{
+				AccessToken:  "accessToken",
+				RefreshToken: "refreshToken",
+				ExpiresOn:    json.Number("84245"),
+				NotBefore:    json.Number("1733696828"),
+				Resource:     testServerID,
+				Type:         "Bearer",
+			},
+			expectErr: false,
+		},
+		{
+			name:          "invalid header",
+			challengePath: "invalid",
+			tokenResponse: "",
+			servURL:       "",
+			expectedToken: adal.Token{},
+			expectErr:     true,
+		},
+		{
+			name:          "empty challenge token path",
+			challengePath: "",
+			tokenResponse: "",
+			servURL:       "",
+			expectedToken: adal.Token{},
+			expectErr:     true,
+		},
+		{
+			name:          "client error",
+			challengePath: path.Join(t.TempDir(), "fake.key"),
+			tokenResponse: "",
+			servURL:       "http://invalid", // simulates client error
+			expectedToken: adal.Token{},
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.tokenResponse != "" {
+					w.Write([]byte(tc.tokenResponse))
+				}
+
+				w.Header().Set("Www-Authenticate", "Basic realm="+tc.challengePath)
+			}))
+			defer srv.Close()
+
+			url := srv.URL
+			if tc.servURL != "" {
+				url = tc.servURL
+			}
+
+			if tc.challengePath != "" && tc.challengePath != "invalid" {
+				// Write the test token in the challenge path
+				err := os.WriteFile(tc.challengePath, []byte("accessToken"), 0644)
+				require.NoError(t, err)
+			}
+
+			token, err := getBearerToken(
+				context.Background(),
+				srv.Client(),
+				url,
+				tc.challengePath,
+				testAPIVersion,
+				testServerID,
+			)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedToken, token)
+		})
+	}
+}

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -33,6 +33,8 @@ type Options struct {
 	UseAzureRMTerraformEnv bool
 	IsPoPTokenEnabled      bool
 	PoPTokenClaims         string
+	HIMDSApiVersion        string
+	HIMDSIdentityEndpoint  string
 }
 
 const (

--- a/pkg/internal/token/provider.go
+++ b/pkg/internal/token/provider.go
@@ -46,6 +46,8 @@ func NewTokenProvider(o *Options) (TokenProvider, error) {
 		return newManagedIdentityToken(o.ClientID, o.IdentityResourceID, o.ServerID)
 	case AzureCLILogin:
 		return newAzureCLIToken(o.ServerID, o.TenantID, o.Timeout)
+	case HIMDSLogin:
+		return newHIMDSToken(o.ServerID, o.HIMDSApiVersion, o.HIMDSIdentityEndpoint)
 	case WorkloadIdentityLogin:
 		return newWorkloadIdentityToken(o.ClientID, o.FederatedTokenFile, o.AuthorityHost, o.ServerID, o.TenantID)
 	case AzureDeveloperCLILogin:

--- a/pkg/token/options.go
+++ b/pkg/token/options.go
@@ -39,4 +39,9 @@ type Options struct {
 
 	AuthorityHost      string
 	FederatedTokenFile string
+
+	// for HIMDSLogin
+
+	HIMDSApiVersion       string
+	HIMDSIdentityEndpoint string
 }

--- a/pkg/token/options_ctor.go
+++ b/pkg/token/options_ctor.go
@@ -40,18 +40,20 @@ func OptionsWithEnv() *Options {
 
 func (opts *Options) toInternalOptions() *token.Options {
 	return &token.Options{
-		LoginMethod:        opts.LoginMethod,
-		Environment:        opts.Environment,
-		TenantID:           opts.TenantID,
-		ServerID:           opts.ServerID,
-		ClientID:           opts.ClientID,
-		ClientSecret:       opts.ClientSecret,
-		ClientCert:         opts.ClientCert,
-		ClientCertPassword: opts.ClientCertPassword,
-		IsPoPTokenEnabled:  opts.IsPoPTokenEnabled,
-		PoPTokenClaims:     opts.PoPTokenClaims,
-		IdentityResourceID: opts.IdentityResourceID,
-		AuthorityHost:      opts.AuthorityHost,
-		FederatedTokenFile: opts.FederatedTokenFile,
+		LoginMethod:           opts.LoginMethod,
+		Environment:           opts.Environment,
+		TenantID:              opts.TenantID,
+		ServerID:              opts.ServerID,
+		ClientID:              opts.ClientID,
+		ClientSecret:          opts.ClientSecret,
+		ClientCert:            opts.ClientCert,
+		ClientCertPassword:    opts.ClientCertPassword,
+		IsPoPTokenEnabled:     opts.IsPoPTokenEnabled,
+		PoPTokenClaims:        opts.PoPTokenClaims,
+		IdentityResourceID:    opts.IdentityResourceID,
+		AuthorityHost:         opts.AuthorityHost,
+		FederatedTokenFile:    opts.FederatedTokenFile,
+		HIMDSApiVersion:       opts.HIMDSApiVersion,
+		HIMDSIdentityEndpoint: opts.HIMDSIdentityEndpoint,
 	}
 }


### PR DESCRIPTION
This is an example of how a caller might use this provider to fetch a token. It may be useful to have exported constants such as `LoginMethod`, `ServerID` for convenience but this hasn't been implement yet to keep the API for `pkg/token` consistent.

```go
package main

import (
	"context"
	"fmt"

	"github.com/Azure/kubelogin/pkg/token"
)

func main() {
	provider, err := token.GetTokenProvider(&token.Options{
		LoginMethod:           "himds",
		HIMDSApiVersion:       "2021-02-01",
		ServerID:              "6dae42f8-4368-4678-94ff-3960e28e3630",
		HIMDSIdentityEndpoint: "http://127.0.0.1:40342/metadata/identity/oauth2/token",
	})
	if err != nil {
		panic(err)
	}

	tkn, err := provider.GetAccessToken(context.Background())
	if err != nil {
		panic(err)
	}

	fmt.Printf("%+v\n", tkn.Token)

}
```

Closes #569 