### PR TITLE
Improve shell completion for convert-config

### DIFF
--- a/pkg/cmd/convert.go
+++ b/pkg/cmd/convert.go
@@ -30,9 +30,11 @@ func newConvertCmd() *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: cobra.NoFileCompletions,
 	}
 
 	o.AddFlags(cmd.Flags())
+	o.AddCompletions(cmd)
 
 	return cmd
 }

--- a/pkg/internal/converter/options.go
+++ b/pkg/internal/converter/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/kubelogin/pkg/internal/token"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -56,4 +57,8 @@ func (o *Options) isSet(name string) bool {
 		}
 	})
 	return found
+}
+
+func (o *Options) AddCompletions(cmd *cobra.Command) {
+	o.TokenOptions.AddCompletions(cmd)
 }

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/kubelogin/pkg/internal/env"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/util/homedir"
 )
@@ -270,4 +271,10 @@ func parsePoPClaims(popClaims string) (map[string]string, error) {
 		return nil, fmt.Errorf("required u-claim not provided for PoP token flow. Please provide the ARM ID of the cluster in the format `u=<ARM_ID>`")
 	}
 	return claimsMap, nil
+}
+
+func (o *Options) AddCompletions(cmd *cobra.Command) {
+	_ = cmd.RegisterFlagCompletionFunc("login", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return supportedLogin, cobra.ShellCompDirectiveNoFileComp
+	})
 }


### PR DESCRIPTION
I would like to improve shell completion of `kubelogin`.
I started with a command and option that I use frequently: `kubelogin convert-config --login`.

### What I did

I found it hard to spot a place where the code naturally fits.
I decided to put it beside the `AddFlags` methods so that I can access non-exported variables (`supportedLogin`)
and do not conflict with existing tests.
The structure is intended to be open for further additions.

Please let me know if this is a good way to go before I add more completions.

### How to verify

Import bash completion for kubelogin:
```bash
source <(kubelogin completion bash)
```

**Without this PR:**
`kubelogin convert-config <TAB><TAB>` => completion of filenames (wrong)
`kubelogin convert-config --login <TAB><TAB>` => completion of filenames (wrong)

**With this PR:**
`kubelogin convert-config <TAB><TAB>` => no completion
`kubelogin convert-config --login <TAB><TAB>` => completion of supported logins