### PR TITLE
Shell completion enhancements

### DIFF
--- a/pkg/cmd/removetokencache.go
+++ b/pkg/cmd/removetokencache.go
@@ -22,6 +22,7 @@ func newRemoveTokenCacheCmd() *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: cobra.NoFileCompletions,
 	}
 
 	cmd.Flags().StringVar(&tokenCacheDir, "token-cache-dir", token.DefaultTokenCacheDir, "directory to cache token")

--- a/pkg/cmd/token.go
+++ b/pkg/cmd/token.go
@@ -37,6 +37,7 @@ func newTokenCmd() *cobra.Command {
 			}
 			return nil
 		},
+		ValidArgsFunction: cobra.NoFileCompletions,
 	}
 
 	o.AddFlags(cmd.Flags())

--- a/pkg/cmd/token.go
+++ b/pkg/cmd/token.go
@@ -41,5 +41,7 @@ func newTokenCmd() *cobra.Command {
 	}
 
 	o.AddFlags(cmd.Flags())
+	o.AddCompletions(cmd)
+
 	return cmd
 }

--- a/pkg/internal/converter/options.go
+++ b/pkg/internal/converter/options.go
@@ -61,7 +61,11 @@ func (o *Options) isSet(name string) bool {
 
 func (o *Options) AddCompletions(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(flagContext, completeContexts(o))
+	_ = cmd.MarkFlagDirname(flagAzureConfigDir)
+	_ = cmd.MarkFlagFilename("kubeconfig", "")
+
 	o.TokenOptions.AddCompletions(cmd)
+
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		// Set a default completion function if none was set. We don't look
 		// up if it does already have one set, because Cobra does this for

--- a/pkg/internal/converter/options.go
+++ b/pkg/internal/converter/options.go
@@ -60,5 +60,23 @@ func (o *Options) isSet(name string) bool {
 }
 
 func (o *Options) AddCompletions(cmd *cobra.Command) {
+	_ = cmd.RegisterFlagCompletionFunc(flagContext, completeContexts(o))
 	o.TokenOptions.AddCompletions(cmd)
+}
+
+func completeContexts(o *Options) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		clientConfig := o.configFlags.ToRawKubeConfigLoader()
+		config, err := clientConfig.RawConfig()
+		if err != nil {
+			cobra.CompDebugln(fmt.Sprintf("unable to load kubeconfig: %s", err), false)
+		}
+
+		contexts := make([]string, 0, len(config.Contexts))
+		for name, _ := range config.Contexts {
+			contexts = append(contexts, name)
+		}
+
+		return contexts, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/pkg/internal/converter/options.go
+++ b/pkg/internal/converter/options.go
@@ -62,6 +62,12 @@ func (o *Options) isSet(name string) bool {
 func (o *Options) AddCompletions(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(flagContext, completeContexts(o))
 	o.TokenOptions.AddCompletions(cmd)
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
+	})
 }
 
 func completeContexts(o *Options) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -277,6 +277,9 @@ func (o *Options) AddCompletions(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc("login", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return supportedLogin, cobra.ShellCompDirectiveNoFileComp
 	})
+	_ = cmd.MarkFlagFilename("client-certificate", "pfx", "cert")
+	_ = cmd.MarkFlagFilename("federated-token-file", "")
+	_ = cmd.MarkFlagDirname("token-cache-dir")
 
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 		// Set a default completion function if none was set. We don't look

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -277,4 +277,11 @@ func (o *Options) AddCompletions(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc("login", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return supportedLogin, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
+	})
 }


### PR DESCRIPTION
This PR features several enhancements to shell completion:

- no filename completion after command names, e.g. `kubelogin get-token <TAB><TAB>`
- completion for `get-token --login`, see #582 
- completion for `kubelogin convert-kubeconfig --context`
- only flags that take filenames or dirnames have file or dirname completion

For hints on how to verify, see #582