### PR TITLE
Add disable-instance-discovery option in interactive pop mode

### DIFF
--- a/docs/book/src/cli/get-token.md
+++ b/docs/book/src/cli/get-token.md
@@ -20,6 +20,7 @@ ZURE_CLIENT_CERTIFICATE_PASSWORD environment variable
       --client-id string                     AAD client application ID. It may be specified in AAD_SERVICE_PRINCIPAL_CLIENT_ID or AZURE_CLIENT_ID environment variable
       --client-secret string                 AAD client application secret. Used in spn login. It may be specified in AAD_SERVICE_PRINCIPAL_CLIENT_SECRET or AZURE_CLIENT_S
 ECRET environment variable
+      --disable-instance-discovery           set to true to disable instance discovery in environments with their own Identity Provider (not Entra ID/AAD) that does not have instance metadata discovery endpoint.
   -e, --environment string                   Azure environment name (default "AzurePublicCloud")
       --federated-token-file string          Workload Identity federated token file. It may be specified in AZURE_FEDERATED_TOKEN_FILE environment variable
   -h, --help                                 help for get-token

--- a/pkg/internal/pop/msal_public.go
+++ b/pkg/internal/pop/msal_public.go
@@ -14,6 +14,7 @@ type PublicClientOptions struct {
 	ClientID                 string
 	DisableInstanceDiscovery bool
 	Options                  *azcore.ClientOptions
+	TenantID                 string
 }
 
 // AcquirePoPTokenInteractive acquires a PoP token using MSAL's interactive login flow.
@@ -44,6 +45,7 @@ func AcquirePoPTokenInteractive(
 				PoPKey: popKey,
 			},
 		),
+		public.WithTenantID(pcOptions.TenantID),
 	)
 	if err != nil {
 		return "", -1, fmt.Errorf("failed to create PoP token with interactive flow: %w", err)
@@ -82,6 +84,7 @@ func AcquirePoPTokenByUsernamePassword(
 				PoPKey: popKey,
 			},
 		),
+		public.WithTenantID(pcOptions.TenantID),
 	)
 	if err != nil {
 		return "", -1, fmt.Errorf("failed to create PoP token with username/password flow: %w", err)
@@ -91,7 +94,7 @@ func AcquirePoPTokenByUsernamePassword(
 }
 
 // getPublicClient returns an instance of the msal `public` client based on the provided options
-// The instance discovery will be disable on private cloud
+// The instance discovery should be disabled on private cloud
 func getPublicClient(pcOptions *PublicClientOptions) (*public.Client, error) {
 	var client public.Client
 	var err error

--- a/pkg/internal/pop/msal_public_test.go
+++ b/pkg/internal/pop/msal_public_test.go
@@ -124,6 +124,7 @@ func TestAcquirePoPTokenByUsernamePassword(t *testing.T) {
 					Authority: authority,
 					ClientID:  tc.p.clientID,
 					Options:   &clientOpts,
+					TenantID:  tc.p.tenantID,
 				},
 			)
 			defer vcrRecorder.Stop()
@@ -171,6 +172,7 @@ func TestGetPublicClient(t *testing.T) {
 					Cloud:     cloud.AzurePublic,
 					Transport: httpClient,
 				},
+				TenantID: testutils.TenantID,
 			},
 			expectedError: nil,
 		},
@@ -183,6 +185,7 @@ func TestGetPublicClient(t *testing.T) {
 				Options: &azcore.ClientOptions{
 					Cloud: cloud.AzurePublic,
 				},
+				TenantID: testutils.TenantID,
 			},
 			expectedError: nil,
 		},
@@ -195,6 +198,7 @@ func TestGetPublicClient(t *testing.T) {
 				Options: &azcore.ClientOptions{
 					Cloud: cloud.AzurePublic,
 				},
+				TenantID: testutils.TenantID,
 			},
 			expectedError: fmt.Errorf("unable to create public client"),
 		},

--- a/pkg/internal/pop/msal_public_test.go
+++ b/pkg/internal/pop/msal_public_test.go
@@ -120,7 +120,7 @@ func TestAcquirePoPTokenByUsernamePassword(t *testing.T) {
 				scopes,
 				tc.p.username,
 				tc.p.password,
-				&PublicClientOptions{
+				&MsalClientOptions{
 					Authority: authority,
 					ClientID:  tc.p.clientID,
 					Options:   &clientOpts,
@@ -159,13 +159,13 @@ func TestGetPublicClient(t *testing.T) {
 
 	testCase := []struct {
 		testName      string
-		pcOptions     *PublicClientOptions
+		msalOptions   *MsalClientOptions
 		expectedError error
 	}{
 		{
 			// Test using custom HTTP transport
 			testName: "TestGetPublicClientWithCustomTransport",
-			pcOptions: &PublicClientOptions{
+			msalOptions: &MsalClientOptions{
 				Authority: authority,
 				ClientID:  testutils.ClientID,
 				Options: &azcore.ClientOptions{
@@ -179,7 +179,7 @@ func TestGetPublicClient(t *testing.T) {
 		{
 			// Test using default HTTP transport
 			testName: "TestGetPublicClientWithDefaultTransport",
-			pcOptions: &PublicClientOptions{
+			msalOptions: &MsalClientOptions{
 				Authority: authority,
 				ClientID:  testutils.ClientID,
 				Options: &azcore.ClientOptions{
@@ -192,7 +192,7 @@ func TestGetPublicClient(t *testing.T) {
 		{
 			// Test using incorrectly formatted authority
 			testName: "TestGetPublicClientWithBadAuthority",
-			pcOptions: &PublicClientOptions{
+			msalOptions: &MsalClientOptions{
 				Authority: "login.microsoft.com",
 				ClientID:  testutils.ClientID,
 				Options: &azcore.ClientOptions{
@@ -209,7 +209,7 @@ func TestGetPublicClient(t *testing.T) {
 
 	for _, tc := range testCase {
 		t.Run(tc.testName, func(t *testing.T) {
-			client, err = getPublicClient(tc.pcOptions)
+			client, err = getPublicClient(tc.msalOptions)
 
 			if tc.expectedError != nil {
 				if !testutils.ErrorContains(err, tc.expectedError.Error()) {

--- a/pkg/internal/token/interactive.go
+++ b/pkg/internal/token/interactive.go
@@ -80,6 +80,7 @@ func (p *InteractiveToken) TokenWithOptions(ctx context.Context, options *azcore
 				ClientID:                 p.clientID,
 				DisableInstanceDiscovery: p.disableInstanceDiscovery,
 				Options:                  &clientOpts,
+				TenantID:                 p.tenantID,
 			},
 		)
 		if err != nil {

--- a/pkg/internal/token/interactive.go
+++ b/pkg/internal/token/interactive.go
@@ -75,7 +75,7 @@ func (p *InteractiveToken) TokenWithOptions(ctx context.Context, options *azcore
 			ctx,
 			p.popClaims,
 			scopes,
-			&pop.PublicClientOptions{
+			&pop.MsalClientOptions{
 				Authority:                authorityFromConfig.String(),
 				ClientID:                 p.clientID,
 				DisableInstanceDiscovery: p.disableInstanceDiscovery,

--- a/pkg/internal/token/interactive_test.go
+++ b/pkg/internal/token/interactive_test.go
@@ -59,6 +59,7 @@ func TestNewInteractiveToken(t *testing.T) {
 				tc.resourceID,
 				tc.tenantID,
 				tc.popClaims,
+				false,
 			)
 
 			if tc.expectedError != "" {

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	IsPoPTokenEnabled          bool
 	PoPTokenClaims             string
 	DisableEnvironmentOverride bool
+	DisableInstanceDiscovery   bool
 }
 
 const (
@@ -110,6 +111,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		fmt.Sprintf("Timeout duration for Azure CLI token requests. It may be specified in %s environment variable", "AZURE_CLI_TIMEOUT"))
 	fs.StringVar(&o.PoPTokenClaims, "pop-claims", o.PoPTokenClaims, "contains a comma-separated list of claims to attach to the pop token in the format `key=val,key2=val2`. At minimum, specify the ARM ID of the cluster as `u=ARM_ID`")
 	fs.BoolVar(&o.DisableEnvironmentOverride, "disable-environment-override", o.DisableEnvironmentOverride, "Enable or disable the use of env-variables. Default false")
+	fs.BoolVar(&o.DisableInstanceDiscovery, "disable-instance-discovery", o.DisableInstanceDiscovery, "set to true to disable instance discovery in environments with their own simple Identity Provider (not AAD) that do not have instance metadata discovery endpoint. Default false")
 }
 
 func (o *Options) Validate() error {

--- a/pkg/internal/token/provider.go
+++ b/pkg/internal/token/provider.go
@@ -34,14 +34,14 @@ func NewTokenProvider(o *Options) (TokenProvider, error) {
 	case DeviceCodeLogin:
 		return newDeviceCodeTokenProvider(*oAuthConfig, o.ClientID, o.ServerID, o.TenantID)
 	case InteractiveLogin:
-		return newInteractiveTokenProvider(*oAuthConfig, o.ClientID, o.ServerID, o.TenantID, popClaimsMap)
+		return newInteractiveTokenProvider(*oAuthConfig, o.ClientID, o.ServerID, o.TenantID, popClaimsMap, o.DisableInstanceDiscovery)
 	case ServicePrincipalLogin:
 		if o.IsLegacy {
 			return newLegacyServicePrincipalToken(*oAuthConfig, o.ClientID, o.ClientSecret, o.ClientCert, o.ClientCertPassword, o.ServerID, o.TenantID)
 		}
 		return newServicePrincipalTokenProvider(cloudConfiguration, o.ClientID, o.ClientSecret, o.ClientCert, o.ClientCertPassword, o.ServerID, o.TenantID, false, popClaimsMap)
 	case ROPCLogin:
-		return newResourceOwnerTokenProvider(*oAuthConfig, o.ClientID, o.Username, o.Password, o.ServerID, o.TenantID, popClaimsMap)
+		return newResourceOwnerTokenProvider(*oAuthConfig, o.ClientID, o.Username, o.Password, o.ServerID, o.TenantID, popClaimsMap, o.DisableInstanceDiscovery)
 	case MSILogin:
 		return newManagedIdentityToken(o.ClientID, o.IdentityResourceID, o.ServerID)
 	case AzureCLILogin:

--- a/pkg/internal/token/ropc.go
+++ b/pkg/internal/token/ropc.go
@@ -87,7 +87,7 @@ func (p *resourceOwnerToken) tokenWithOptions(ctx context.Context, options *azco
 			scopes,
 			p.username,
 			p.password,
-			&pop.PublicClientOptions{
+			&pop.MsalClientOptions{
 				Authority:                authorityFromConfig.String(),
 				ClientID:                 p.clientID,
 				DisableInstanceDiscovery: p.disableInstanceDiscovery,

--- a/pkg/internal/token/ropc.go
+++ b/pkg/internal/token/ropc.go
@@ -92,6 +92,7 @@ func (p *resourceOwnerToken) tokenWithOptions(ctx context.Context, options *azco
 				ClientID:                 p.clientID,
 				DisableInstanceDiscovery: p.disableInstanceDiscovery,
 				Options:                  &clientOpts,
+				TenantID:                 p.tenantID,
 			},
 		)
 		if err != nil {

--- a/pkg/internal/token/ropc_test.go
+++ b/pkg/internal/token/ropc_test.go
@@ -91,6 +91,7 @@ func TestNewResourceOwnerTokenProvider(t *testing.T) {
 				tc.resourceID,
 				tc.tenantID,
 				tc.popClaims,
+				false,
 			)
 
 			if tc.expectedError != "" {


### PR DESCRIPTION
For Winfield, we need to disable instance discovery in the auth flow, or we will hit error. See details in https://github.com/Azure/kubelogin/issues/555 

Context
Project Winfield is an appliance Virtual Machine (VM) that provides a local control plane for your datacenter. It allows you to deploy and manage the appliance easily and use Azure Arc and Azure management capabilities in a disconnected or air-gapped environment. Project Winfield is designed to help you meet specific regulatory requirements when you need a local control plane.