### PR TITLE
ignore cache create failure

### DIFF
--- a/pkg/internal/token/clientcertcredential.go
+++ b/pkg/internal/token/clientcertcredential.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
 	"golang.org/x/crypto/pkcs12"
+	"k8s.io/klog/v2"
 )
 
 type ClientCertificateCredential struct {
@@ -39,7 +40,7 @@ func newClientCertificateCredential(opts *Options) (CredentialProvider, error) {
 	if opts.UsePersistentCache {
 		c, err = cache.New(nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cache: %w", err)
+			klog.V(5).Infof("failed to create cache: %v", err)
 		}
 	}
 

--- a/pkg/internal/token/clientsecretcredential.go
+++ b/pkg/internal/token/clientsecretcredential.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
+	"k8s.io/klog/v2"
 )
 
 type ClientSecretCredential struct {
@@ -33,7 +34,7 @@ func newClientSecretCredential(opts *Options) (CredentialProvider, error) {
 	if opts.UsePersistentCache {
 		c, err = cache.New(nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cache: %w", err)
+			klog.V(5).Infof("failed to create cache: %v", err)
 		}
 	}
 

--- a/pkg/internal/token/devicecodecredential.go
+++ b/pkg/internal/token/devicecodecredential.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
+	"k8s.io/klog/v2"
 )
 
 type DeviceCodeCredential struct {
@@ -31,7 +32,7 @@ func newDeviceCodeCredential(opts *Options, record azidentity.AuthenticationReco
 	if opts.UsePersistentCache {
 		c, err = cache.New(nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cache: %w", err)
+			klog.V(5).Infof("failed to create cache: %v", err)
 		}
 	}
 

--- a/pkg/internal/token/interactivebrowsercredential.go
+++ b/pkg/internal/token/interactivebrowsercredential.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
+	"k8s.io/klog/v2"
 )
 
 type InteractiveBrowserCredential struct {
@@ -30,7 +31,7 @@ func newInteractiveBrowserCredential(opts *Options, record azidentity.Authentica
 	if opts.UsePersistentCache {
 		c, err = cache.New(nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cache: %w", err)
+			klog.V(5).Infof("failed to create cache: %v", err)
 		}
 	}
 

--- a/pkg/internal/token/usernamepasswordcredential.go
+++ b/pkg/internal/token/usernamepasswordcredential.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
+	"k8s.io/klog/v2"
 )
 
 type UsernamePasswordCredential struct {
@@ -36,7 +37,7 @@ func newUsernamePasswordCredential(opts *Options, record azidentity.Authenticati
 	if opts.UsePersistentCache {
 		c, err = cache.New(nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cache: %w", err)
+			klog.V(5).Infof("failed to create cache: %v", err)
 		}
 	}
 

--- a/pkg/internal/token/workloadidentitycredential.go
+++ b/pkg/internal/token/workloadidentitycredential.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -40,7 +41,7 @@ func newWorkloadIdentityCredential(opts *Options) (CredentialProvider, error) {
 	if opts.UsePersistentCache {
 		c, err = cache.New(nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create cache: %w", err)
+			klog.V(5).Infof("failed to create cache: %v", err)
 		}
 	}
 


### PR DESCRIPTION
according to doc, when fails to create cache, authentication can still proceed
https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/TOKEN_CACHING.MD#Persistent-token-caching

fixes #642 