### PR TITLE
docs: clarify sp login-mode precedence

### DIFF
--- a/docs/book/src/concepts/login-modes/sp.md
+++ b/docs/book/src/concepts/login-modes/sp.md
@@ -5,6 +5,11 @@ The supported credentials are password and pfx client certificate.
 
 The token will not be cached on the filesystem.
 
+```text
+When AAD_SERVICE_PRINCIPAL_CLIENT_ID and AZURE_CLIENT_ID both exists,
+AZURE_CLIENT_ID takes precedence.
+```
+
 ## Usage Examples
 
 ### Client secret in environment variable


### PR DESCRIPTION
This note clarifies which environment variable takes precedence when both are set,
it might help users avoid confusion and ensuring predictable authentication behavior