### PR TITLE
Vithumma/fix kubelogin bug

### DIFF
--- a/pkg/internal/token/execCredentialPlugin.go
+++ b/pkg/internal/token/execCredentialPlugin.go
@@ -37,12 +37,12 @@ func New(o *Options) (ExecCredentialPlugin, error) {
 		// Create PoP token cache using the official MSAL & MSAL extension libraries.
 		popTokenCache, err := popcache.NewCache(o.AuthRecordCacheDir)
 		if err != nil {
-			// Fallback: Log warning and continue without PoP token caching when cache creation fails
-			klog.V(2).Infof("PoP token caching disabled due to secure storage failure (likely container environment): %v", err)
-			popTokenCache = nil
-			// Continue execution without using cached PoP tokens
+			// Continue without caching; leave popTokenCache unset (nil field)
+			// so GetPoPTokenCache() returns an untyped nil interface.
+			klog.V(2).Infof("PoP token caching disabled: %v", err)
+		} else {
+			o.setPoPTokenCache(popTokenCache)
 		}
-		o.setPoPTokenCache(popTokenCache)
 	}
 
 	return &execCredentialPlugin{

--- a/pkg/internal/token/options.go
+++ b/pkg/internal/token/options.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/kubelogin/pkg/internal/env"
 	"github.com/Azure/kubelogin/pkg/internal/pop"
 	popcache "github.com/Azure/kubelogin/pkg/internal/pop/cache"
+	msalcache "github.com/AzureAD/microsoft-authentication-library-for-go/apps/cache"
 )
 
 // PoPKeyProvider provides PoP keys based on the configured cache policy
@@ -378,9 +379,14 @@ func (o *Options) AddCompletions(cmd *cobra.Command) {
 	})
 }
 
-// GetPoPTokenCache returns the PoP token cache if available.
-// Returns nil if PoP is disabled or cache creation failed (e.g., container environments).
-func (o *Options) GetPoPTokenCache() *popcache.Cache {
+// GetPoPTokenCache returns the PoP token cache if available, or nil if PoP is
+// disabled or cache creation failed (e.g., container environments).
+// It returns the interface type so that a nil field produces an untyped nil,
+// which correctly compares as nil in downstream interface checks.
+func (o *Options) GetPoPTokenCache() msalcache.ExportReplace {
+	if o.popTokenCache == nil {
+		return nil
+	}
 	return o.popTokenCache
 }
 


### PR DESCRIPTION
Fix bug - > PoP token support crashes with nil pointer in cache.Replace when running non-root

https://github.com/Azure/kubelogin/issues/734