### PR TITLE
Return errors when cache cleanup fails

### DIFF
--- a/pkg/cmd/removecachedir.go
+++ b/pkg/cmd/removecachedir.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Azure/kubelogin/pkg/internal/token"
 	"github.com/spf13/cobra"
-	klog "k8s.io/klog/v2"
 )
 
 // newRemoveAuthRecordCacheCmd provides a cobra command for removing token cache sub command
@@ -18,7 +18,7 @@ func newRemoveAuthRecordCacheCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := os.RemoveAll(authRecordCacheDir); err != nil {
-				klog.V(5).Infof("unable to delete authentication record cache in '%s': %s", authRecordCacheDir, err)
+				return fmt.Errorf("unable to delete authentication record cache in %q: %w", authRecordCacheDir, err)
 			}
 			return nil
 		},

--- a/pkg/cmd/removecachedir_test.go
+++ b/pkg/cmd/removecachedir_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRemoveCacheDirReturnsErrorOnFailure(t *testing.T) {
+	badPath := pathWithFileAsParent(t)
+	cmd := newRemoveAuthRecordCacheCmd()
+	err := executeCommand(cmd, "--cache-dir", badPath)
+
+	if err == nil {
+		t.Fatal("expected remove-cache-dir to return an error when cache deletion fails")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected wrapped cache deletion path error, got: %v", err)
+	}
+}
+
+func TestRemoveTokensReturnsErrorOnFailure(t *testing.T) {
+	badPath := pathWithFileAsParent(t)
+	cmd := newRemoveAuthRecordCacheCmdDeprecated()
+	err := executeCommand(cmd, "--token-cache-dir", badPath)
+
+	if err == nil {
+		t.Fatal("expected remove-tokens to return an error when cache deletion fails")
+	}
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("expected wrapped cache deletion path error, got: %v", err)
+	}
+}
+
+func TestRemoveCacheDirSucceedsForNonexistentPath(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "missing-cache")
+	cmd := newRemoveAuthRecordCacheCmd()
+	if err := executeCommand(cmd, "--cache-dir", cacheDir); err != nil {
+		t.Fatalf("expected remove-cache-dir to succeed for a nonexistent path, got: %v", err)
+	}
+}
+
+func TestRemoveTokensSucceedsForNonexistentPath(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "missing-cache")
+	cmd := newRemoveAuthRecordCacheCmdDeprecated()
+	if err := executeCommand(cmd, "--token-cache-dir", cacheDir); err != nil {
+		t.Fatalf("expected remove-tokens to succeed for a nonexistent path, got: %v", err)
+	}
+}
+
+func executeCommand(cmd *cobra.Command, args ...string) error {
+	// Discard command output, including deprecation warnings
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func pathWithFileAsParent(t *testing.T) string {
+	t.Helper()
+
+	// Use a file parent to make os.RemoveAll fail deterministically
+	parentFile := filepath.Join(t.TempDir(), "cache-parent")
+	if err := os.WriteFile(parentFile, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("failed to create parent file: %v", err)
+	}
+	return filepath.Join(parentFile, "child")
+}

--- a/pkg/cmd/removetokencache.go
+++ b/pkg/cmd/removetokencache.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/Azure/kubelogin/pkg/internal/token"
 	"github.com/spf13/cobra"
-	klog "k8s.io/klog/v2"
 )
 
 // newRemoveAuthRecordCacheCmd provides a cobra command for removing token cache sub command
@@ -18,7 +18,7 @@ func newRemoveAuthRecordCacheCmdDeprecated() *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := os.RemoveAll(authRecordCacheDir); err != nil {
-				klog.V(5).Infof("unable to delete authentication record cache in '%s': %s", authRecordCacheDir, err)
+				return fmt.Errorf("unable to delete authentication record cache in %q: %w", authRecordCacheDir, err)
 			}
 			return nil
 		},


### PR DESCRIPTION
`remove-cache-dir` and deprecated `remove-tokens` previously logged `os.RemoveAll` failures only at verbose level and still returned success. This change returns the removal error with context while preserving success for missing cache paths.

Tests cover both commands with explicit temporary cache paths, including a deterministic removal failure using a regular file as an intermediate path component.