### PR TITLE
docs: explain how to switch device code login to interactive

### DIFF
--- a/docs/book/src/concepts/login-modes/devicecode.md
+++ b/docs/book/src/concepts/login-modes/devicecode.md
@@ -21,6 +21,25 @@ kubectl get nodes
 
 ```
 
+## Using Interactive Mode Instead
+
+Device code login asks the user to open a URL and type a code by hand. Entra ID does not return the
+optional `verification_uri_complete` field from [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628#section-3.3.1),
+so the URL and the code cannot be combined into a single link. When the machine running `kubectl`
+has a browser, [web browser interactive mode](./interactive.md) avoids the copying altogether.
+
+If the kubeconfig was provisioned for you and already pins `--login=devicecode` in its exec args,
+you don't have to edit it. Environment variables are applied after the flags are parsed, so
+`AAD_LOGIN_METHOD` takes precedence over the login mode stored in the kubeconfig:
+
+```sh
+export AAD_LOGIN_METHOD=interactive
+
+kubectl get nodes
+```
+
+Passing `--disable-environment-override` turns this off and keeps the login mode from the kubeconfig.
+
 ## Restrictions
 
 - Device code login mode doesn't work when Conditional Access policy is configured on AAD tenant. Use [web browser interactive mode](./interactive.md) instead.


### PR DESCRIPTION
## Why

Device code login makes the user copy a URL, open it, then separately copy a code into the page. That is two manual steps every time the token is refreshed.

There is no client-side fix for the two-step part. Entra ID does not return the optional `verification_uri_complete` field from [RFC 8628 §3.3.1](https://datatracker.ietf.org/doc/html/rfc8628#section-3.3.1), and [Microsoft documents that omission explicitly](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code), so the URL and the code cannot be collapsed into one clickable link. When a browser is available, interactive mode already removes the copying entirely.

The Device Code page mentions interactive mode only under Restrictions, as a workaround for Conditional Access. Two things a user hitting the copy-paste friction needs aren't written down:

- interactive mode answers the friction itself, not only Conditional Access
- `AAD_LOGIN_METHOD` is read in `UpdateFromEnv()` after the flags are parsed, so it overrides a `--login=devicecode` that is already baked into a kubeconfig the user was handed and may not want to edit

The second one is the non-obvious part. The `get-token` help says the login method "may be specified in AAD_LOGIN_METHOD environment variable", which reads as an alternative to the flag rather than something that wins over it. I only established the precedence by testing it.

## What changed

A section on the Device Code page covering both points, plus a note that `--disable-environment-override` opts out.

## Testing done

Precedence verified against a non-existent tenant so the credential type in the error names which mode actually ran. All three runs pass `-l devicecode` explicitly, mirroring a provisioned kubeconfig:

| # | Env | Result |
|---|-----|--------|
| A | none | device code path |
| B | `AAD_LOGIN_METHOD=interactive` | `InteractiveBrowserCredential` — env won |
| C | `AAD_LOGIN_METHOD=interactive` + `--disable-environment-override` | device code path — opt-out honored |

<details><summary>Raw logs</summary>

```console
$ DUMMY="--server-id=00000000-0000-0000-0000-00000000aaaa \
         --client-id=00000000-0000-0000-0000-00000000bbbb \
         --tenant-id=00000000-0000-0000-0000-00000000cccc"

### A: -l devicecode, no env
$ kubelogin get-token -l devicecode --cache-dir="$(mktemp -d)" $DUMMY
Error: failed to authenticate: unable to resolve an endpoint: http call(https://login.microsoftonline.com/00000000-0000-0000-0000-00000000cccc/v2.0/.well-known/openid-configuration)(GET) error: reply status code was 400:
{"error":"invalid_tenant","error_description":"AADSTS90002: Tenant '00000000-0000-0000-0000-00000000cccc' not found. ..."}

### B: same args + AAD_LOGIN_METHOD=interactive
$ AAD_LOGIN_METHOD=interactive kubelogin get-token -l devicecode --cache-dir="$(mktemp -d)" $DUMMY
Error: failed to authenticate: InteractiveBrowserCredential authentication failed.
GET https://login.microsoftonline.com/00000000-0000-0000-0000-00000000cccc/v2.0/.well-known/openid-configuration
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request

### C: same args + --disable-environment-override
$ AAD_LOGIN_METHOD=interactive kubelogin get-token -l devicecode --disable-environment-override --cache-dir="$(mktemp -d)" $DUMMY
Error: failed to authenticate: unable to resolve an endpoint: http call(https://login.microsoftonline.com/00000000-0000-0000-0000-00000000cccc/v2.0/.well-known/openid-configuration)(GET) error: reply status code was 400:
{"error":"invalid_tenant","error_description":"AADSTS90002: Tenant '00000000-0000-0000-0000-00000000cccc' not found. ..."}
```

Book builds and the new section renders with working links:

```console
$ make -C docs/book build
/Users/.../docs/book/bin/mdbook build
2026-08-06 00:52:39 [INFO] (mdbook::book): Book building has started
2026-08-06 00:52:39 [INFO] (mdbook::book): Running the html backend
EXIT=0

$ grep -o 'href="./interactive.html"' docs/book/book/concepts/login-modes/devicecode.html
href="./interactive.html"
```

</details>

Separately confirmed on a real tenant that `AAD_LOGIN_METHOD=interactive` flips an untouched `--login=devicecode` kubeconfig from printing a device code to opening the browser, and that `kubectl` then works against the cluster.

## Considered and left out

Making device code itself open a browser, at `verification_uri` or at an `otc=`-prefilled URL. Auto-opening is redundant where interactive already works and wrong where a browser is absent, which is device code's reason to exist. The `otc=` prefill is undocumented and mainly known as a device code phishing vector, so kubelogin emitting that URL shape seemed like the wrong pattern to teach.
